### PR TITLE
Clarify current repo contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ docker run --rm -e KAGGLE_USERNAME=$KAGGLE_USERNAME -e KAGGLE_KEY=$KAGGLE_KEY ml
 
 ## Repository layout
 
+Note: at the moment this repo only includes the legacy `ai_arisha.py` notebook
+and this `AGENTS.md` guide. The modular directory tree listed below is the
+intended structure that will be implemented over time.
+
 ```
 ai_arisha.py            ← original Colab notebook (read-only legacy)
 AGENTS.md               ← contributor guidelines & architecture notes


### PR DESCRIPTION
## Summary
- clarify that repo currently contains only the original Colab notebook and AGENTS guidelines
- emphasize that the modular tree in README/AGENTS is the planned layout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845605fcbe88325b5d3dafde4fe32eb