### PR TITLE
Add dataset README and update docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ Your job is to migrate Google Colab notebook ai_arisha.py to several classes git
 1. This file is only a quick-start contributor guide.
 2. Your job is to adapt google colab python code to Github.
 3. KAGGLE_USERNAME, KAGGLE_KEY are in secrets
+4. Never commit downloaded Kaggle data or personal API keys
 
 # Proposed project structure:
 ML_classification/

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ python scripts/download_data.py
 make train
 ````
 
+See [data/README.md](data/README.md) for dataset licence notes.
+
 **Prefer Docker?**
 
 ```bash

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,5 @@
+# Dataset licence
+
+The dataset used for this project is the Kaggle "Loan Approval Prediction Dataset" (`architsharma01/loan-approval-prediction-dataset`).
+It is available only to users who agree to the Kaggle terms of use and dataset licence. Do not upload the raw dataset to this repository.
+Use `scripts/download_data.py` with your Kaggle credentials to obtain the files locally.


### PR DESCRIPTION
## Summary
- warn not to commit Kaggle data or API keys
- add `data/README.md` placeholder for dataset licence
- link to the data README from the quick-start section

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845607413fc8325874e8619e212a90a