### PR TITLE
Clarify reference to NOTES.md in AGENTS guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ ML_classification/
 - **Ensure local tests pass** before opening a PR.
 - **Each PR requires at least one reviewer.**
 
-to understand the current stage, past decisions, and open questions tied to the spec.
+Read `NOTES.md` and `TODO.md` to understand the current stage, past decisions, and open questions tied to the spec.
 
 Refer to `README.md` and full documentation in `docs/` for further details on features and architecture.
 


### PR DESCRIPTION
## Summary
- clarify that contributors should read `NOTES.md` and `TODO.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684564fd8bec8325935f99357c46cde9