### PR TITLE
Format tree feature selector args

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -26,3 +26,4 @@ corresponding TODO items.
 2025-06-10: Implemented Kaggle download script with env auth, added dataprep module and unit tests.
 2025-06-10: Added train/eval modules for logistic regression and decision tree with stratified split utility. Updated Makefile, Dockerfile, README and added basic model tests.
 
+2025-06-08: Reformatted tree_feature_selector arguments to multiple lines.

--- a/src/selection.py
+++ b/src/selection.py
@@ -15,7 +15,12 @@ def calculate_vif(df: pd.DataFrame, cols: list[str]) -> pd.Series:
   return pd.Series([vif(arr, i) for i in range(arr.shape[1])], index=cols)
 
 
-def tree_feature_selector(X: pd.DataFrame, y: pd.Series, n_estimators: int = 100, top: int = 10) -> list[str]:
+def tree_feature_selector(
+  X: pd.DataFrame,
+  y: pd.Series,
+  n_estimators: int = 100,
+  top: int = 10,
+) -> list[str]:
   """Select important features using an ExtraTrees classifier."""
   clf = ExtraTreesClassifier(n_estimators=n_estimators, random_state=0)
   clf.fit(X, y)


### PR DESCRIPTION
## Summary
- wrap `tree_feature_selector` arguments on multiple lines per AGENTS style
- document change in NOTES

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6845745d9dd48325896e460bafba2ee3