### PR TITLE
Add evaluation make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@ train-logreg:
 	python -m src.models.logreg
 
 train-cart:
-	python -m src.models.cart
+        python -m src.models.cart
 
 train: train-logreg train-cart
+
+eval:
+	python -m src.evaluate

--- a/NOTES.md
+++ b/NOTES.md
@@ -50,3 +50,4 @@ corresponding TODO items.
 2025-06-08: Refreshed README repository layout and checked TODO item.
 2025-06-08: Adjusted CI workflow to invoke pytest via python -m.
 2025-06-15: Added PYTHONPATH env var in CI to fix ModuleNotFoundError during tests.
+2025-06-16: Added make eval target and expanded README with evaluation instructions and fairness guidance.

--- a/README.md
+++ b/README.md
@@ -41,12 +41,16 @@ python scripts/download_data.py
 
 # Train, evaluate and store artefacts in artefacts/
 make train            # run both models
+make eval             # evaluate trained models and check fairness
 # or individually
 make train-logreg
 make train-cart
 ```
 
 See [data/README.md](data/README.md) for dataset licence notes.
+
+`make eval` prints test-set metrics and the worst four-fifths ratio across
+protected groups. A ratio below **0.8** warns of possible bias.
 
 **Prefer Docker?**
 


### PR DESCRIPTION
## Summary
- add `eval` make target
- document running `make eval` and fairness ratio interpretation
- record the docs update in NOTES

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845879b5b608325b7f9fd40c92f7a04