### PR TITLE
Add fairness helper

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -50,3 +50,4 @@ corresponding TODO items.
 2025-06-08: Refreshed README repository layout and checked TODO item.
 2025-06-08: Adjusted CI workflow to invoke pytest via python -m.
 2025-06-15: Added PYTHONPATH env var in CI to fix ModuleNotFoundError during tests.
+2025-06-16: Added fairness module with four_fifths_ratio helper and unit tests.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -4,6 +4,7 @@ from .features import FeatureEngineer
 from .diagnostics import chi_square_tests, correlation_heatmap
 from .preprocessing import build_preprocessor, safe_transform
 from .selection import calculate_vif, tree_feature_selector
+from .fairness import four_fifths_ratio
 
 __all__ = [
     "FeatureEngineer",
@@ -13,4 +14,5 @@ __all__ = [
     "safe_transform",
     "calculate_vif",
     "tree_feature_selector",
+    "four_fifths_ratio",
 ]

--- a/src/fairness.py
+++ b/src/fairness.py
@@ -1,0 +1,43 @@
+"""Fairness auditing helpers."""
+
+from __future__ import annotations
+
+import pandas as pd
+from typing import Sequence
+
+__all__ = ["four_fifths_ratio"]
+
+
+def four_fifths_ratio(
+    y_true: Sequence[int],
+    y_pred: Sequence[int],
+    group: Sequence,
+) -> float:
+    """Return four-fifths rule TPR ratio for ``group``.
+
+    Parameters
+    ----------
+    y_true:
+        Binary ground truth labels.
+    y_pred:
+        Binary predictions.
+    group:
+        Protected attribute values used for grouping.
+    """
+    y_true_s = pd.Series(y_true).reset_index(drop=True)
+    y_pred_s = pd.Series(y_pred).reset_index(drop=True)
+    group_s = pd.Series(group).astype(str).reset_index(drop=True)
+    tprs: list[float] = []
+    for g in group_s.unique():
+        mask = group_s == g
+        pos = (y_true_s[mask] == 1)
+        n_pos = int(pos.sum())
+        if n_pos == 0:
+            tprs.append(1.0)
+            continue
+        tp = int((pos & (y_pred_s[mask] == 1)).sum())
+        tprs.append(tp / n_pos)
+    if len(tprs) < 2:
+        return 1.0
+    best = max(tprs)
+    return min(tprs) / best if best else 1.0

--- a/tests/test_fairness.py
+++ b/tests/test_fairness.py
@@ -1,0 +1,23 @@
+from src.fairness import four_fifths_ratio
+
+
+def test_equal_tpr_ratio_is_one():
+  y_true = [1, 0, 1, 0]
+  y_pred = [1, 0, 1, 0]
+  group = ['A', 'A', 'B', 'B']
+  assert four_fifths_ratio(y_true, y_pred, group) == 1.0
+
+
+def test_single_group_returns_one():
+  y_true = [1, 0]
+  y_pred = [1, 1]
+  group = ['A', 'A']
+  assert four_fifths_ratio(y_true, y_pred, group) == 1.0
+
+
+def test_imbalanced_groups_below_threshold():
+  y_true = [1, 1, 1, 1]
+  y_pred = [1, 1, 0, 0]
+  group = ['A', 'A', 'B', 'B']
+  ratio = four_fifths_ratio(y_true, y_pred, group)
+  assert 0 <= ratio < 0.8


### PR DESCRIPTION
## Summary
- implement `fairness.four_fifths_ratio` for group-wise TPR fairness check
- expose the helper in package init
- test fairness ratio utility
- record addition in NOTES

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68458799d5348325ad15e9c2f154388d