### PR TITLE
Add CLI for evaluation

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -53,3 +53,4 @@ corresponding TODO items.
 2025-06-16: Added evaluate.py with nested CV and fairness metrics plus tests.
 2025-06-16: Added make eval target and expanded README with evaluation instructions and fairness guidance.
 
+2025-06-08: Added CLI main entry in evaluate.py and updated tests and README.

--- a/README.md
+++ b/README.md
@@ -49,8 +49,10 @@ make train-cart
 
 See [data/README.md](data/README.md) for dataset licence notes.
 
-`make eval` prints test-set metrics and the worst four-fifths ratio across
-protected groups. A ratio below **0.8** warns of possible bias.
+`make eval` runs `python -m src.evaluate` to compute test metrics and the worst
+four-fifths ratio across protected groups (pass `--group-col` to override the
+default). Metrics are stored in `artefacts/summary_metrics.csv` and printed to
+stdout. A ratio below **0.8** warns of possible bias.
 
 **Prefer Docker?**
 

--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import argparse
 import pandas as pd
 from sklearn.linear_model import LogisticRegression
 from sklearn.tree import DecisionTreeClassifier
@@ -17,12 +18,16 @@ OUTER_CV = StratifiedKFold(n_splits=3, shuffle=True, random_state=1)
 
 
 def _build_pipeline(model, cat_cols: list[str], num_cols: list[str]) -> Pipeline:
-    pre = ColumnTransformer([("cat", OneHotEncoder(handle_unknown="ignore"), cat_cols)],
-                            remainder="passthrough")
+    pre = ColumnTransformer(
+        [("cat", OneHotEncoder(handle_unknown="ignore"), cat_cols)],
+        remainder="passthrough",
+    )
     return Pipeline([("prep", pre), ("model", model)])
 
 
-def _run_nested(df: pd.DataFrame, target: str, model, grid: dict) -> tuple[dict, pd.DataFrame, pd.Series]:
+def _run_nested(
+    df: pd.DataFrame, target: str, model, grid: dict
+) -> tuple[dict, pd.DataFrame, pd.Series]:
     X = df.drop(columns=[target])
     y = df[target]
     cat_cols = X.select_dtypes(include="object").columns.tolist()
@@ -47,17 +52,47 @@ def evaluate_models(
     csv_path: Path = Path("artefacts/summary_metrics.csv"),
 ) -> pd.DataFrame:
     """Return nested-CV metrics for both models and write ``csv_path``."""
-    lr_res, X, y = _run_nested(df, target, LogisticRegression(max_iter=1000), {"model__C": [0.5, 1.5]})
-    dt_res, _, _ = _run_nested(df, target, DecisionTreeClassifier(random_state=42), {"model__max_depth": [None, 3]})
+    lr_res, X, y = _run_nested(
+        df, target, LogisticRegression(max_iter=1000), {"model__C": [0.5, 1.5]}
+    )
+    dt_res, _, _ = _run_nested(
+        df,
+        target,
+        DecisionTreeClassifier(random_state=42),
+        {"model__max_depth": [None, 3]},
+    )
     rows = []
     for name, res in [("logreg", lr_res), ("cart", dt_res)]:
-        rows.append({
-            "model": name,
-            "roc_auc": res["test_roc_auc"].mean(),
-            "pr_auc": res["test_pr_auc"].mean(),
-            "fairness": _fairness(res["estimator"][0], X, y, group_col),
-        })
+        rows.append(
+            {
+                "model": name,
+                "roc_auc": res["test_roc_auc"].mean(),
+                "pr_auc": res["test_pr_auc"].mean(),
+                "fairness": _fairness(res["estimator"][0], X, y, group_col),
+            }
+        )
     out = pd.DataFrame(rows).round(3)
     csv_path.parent.mkdir(parents=True, exist_ok=True)
     out.to_csv(csv_path, index=False)
     return out
+
+
+def main(args: list[str] | None = None) -> None:
+    """CLI entry point evaluating both models on the cleaned dataset."""
+    parser = argparse.ArgumentParser(description="Evaluate trained models")
+    parser.add_argument(
+        "--group-col",
+        help="optional fairness group column",
+        default=None,
+    )
+    ns = parser.parse_args(args)
+
+    from . import dataprep
+
+    df = dataprep.clean(dataprep.load_raw())
+    metrics = evaluate_models(df, group_col=ns.group_col)
+    print(metrics)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -1,22 +1,38 @@
 from __future__ import annotations
 
+import os
+import sys
+import subprocess
+from pathlib import Path
+
 import pandas as pd
 from sklearn.datasets import make_classification
-
-from src.evaluate import evaluate_models
 
 
 def _toy_df() -> pd.DataFrame:
     x, y = make_classification(n_samples=50, n_features=4, random_state=0)
     df = pd.DataFrame(x, columns=[f"f{i}" for i in range(x.shape[1])])
-    df["target"] = y
+    df["Loan_Status"] = pd.Series(y).map({1: "Y", 0: "N"})
     df["group"] = [0] * 25 + [1] * 25
     return df
 
 
-def test_evaluate_models(tmp_path) -> None:
+def test_cli_evaluate(tmp_path) -> None:
     df = _toy_df()
-    csv_path = tmp_path / "summary_metrics.csv"
-    res = evaluate_models(df, target="target", group_col="group", csv_path=csv_path)
-    assert isinstance(res, pd.DataFrame)
-    assert csv_path.exists()
+    data_dir = tmp_path / "data" / "raw"
+    data_dir.mkdir(parents=True)
+    df.to_csv(data_dir / "loan_approval_dataset.csv", index=False)
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1])
+    result = subprocess.run(
+        [sys.executable, "-m", "src.evaluate", "--group-col", "group"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        env=env,
+        check=True,
+    )
+    assert "roc_auc" in result.stdout
+    summary = tmp_path / "artefacts" / "summary_metrics.csv"
+    assert summary.exists()


### PR DESCRIPTION
## Summary
- implement CLI `main` in `src/evaluate.py`
- update README with info on `make eval`
- refactor tests to invoke evaluation via subprocess
- log notes on new CLI

## Testing
- `flake8`
- `black src/evaluate.py tests/test_evaluate.py`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684590bc0c008325a0a7633462c561ea