### PR TITLE
Add unified train CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ train-logreg:
 train-cart:
         python -m src.models.cart
 
-train: train-logreg train-cart
+train:
+        python -m src.train
 
 eval:
 	python -m src.evaluate

--- a/NOTES.md
+++ b/NOTES.md
@@ -55,3 +55,4 @@ corresponding TODO items.
 2025-06-08: integrated FeatureEngineer into model pipelines and updated tests.
 2025-06-08: Added CLI main entry in evaluate.py and updated tests and README.
 
+2025-06-08: Added src/train.py CLI orchestrating both models and updated Makefile to use it.

--- a/src/train.py
+++ b/src/train.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import argparse
+
+from .models import logreg, cart
+
+
+def main(args: list[str] | None = None) -> None:
+    """CLI entry point training the logistic and tree models."""
+    parser = argparse.ArgumentParser(description='Train model pipelines')
+    parser.add_argument(
+        '--model',
+        '-m',
+        action='append',
+        choices=['logreg', 'cart'],
+        help='models to train; defaults to both',
+    )
+    ns = parser.parse_args(args)
+    models = ns.model or ['logreg', 'cart']
+
+    if 'logreg' in models:
+        logreg.main()
+    if 'cart' in models:
+        cart.main()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `src/train.py` orchestrating the two model pipelines
- update Makefile to call new CLI for `make train`
- log update in `NOTES.md`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684594845068832591e3b3846759bcb9