### PR TITLE
Add fairness metric unit tests

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -55,3 +55,4 @@ corresponding TODO items.
 2025-06-08: integrated FeatureEngineer into model pipelines and updated tests.
 2025-06-08: Added CLI main entry in evaluate.py and updated tests and README.
 
+2025-06-08: Added unit tests for fairness metrics.

--- a/tests/test_fairness.py
+++ b/tests/test_fairness.py
@@ -1,0 +1,24 @@
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+from src.fairness import youden_threshold, four_fifths_ratio
+
+
+def test_youden_threshold_range():
+  X = pd.DataFrame({'a': [0, 1, 0, 1], 'b': [1, 1, 0, 0]})
+  y = pd.Series([0, 1, 0, 1])
+  model = LogisticRegression().fit(X, y)
+  thr = youden_threshold(model, X, y)
+  assert 0.0 <= thr <= 1.0
+
+
+def test_four_fifths_ratio_range():
+  X = pd.DataFrame({
+    'feat': [0, 1, 0, 1, 0, 1, 0, 1],
+    'group': [0, 0, 0, 0, 1, 1, 1, 1],
+  })
+  y = pd.Series([1, 1, 0, 0, 1, 0, 1, 0])
+  model = LogisticRegression().fit(X, y)
+  thr = youden_threshold(model, X, y)
+  ratio = four_fifths_ratio(model, X, y, 'group', thr)
+  assert 0.0 <= ratio <= 1.0
+


### PR DESCRIPTION
## Summary
- add tests for youden_threshold and four_fifths_ratio
- log work in NOTES

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684594823da8832586873536d0b19ac2