### PR TITLE
Handle VIF warnings in selection helper

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -58,3 +58,4 @@ corresponding TODO items.
 2025-06-08: Added src/train.py CLI orchestrating both models and updated Makefile to use it.
 
 2025-06-08: Added unit tests for fairness metrics.
+2025-06-08: Wrapped VIF computation in warnings and numpy error state contexts to avoid RuntimeWarning when columns are perfectly collinear.

--- a/src/selection.py
+++ b/src/selection.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import warnings
+
+import numpy as np
 import pandas as pd
 from statsmodels.stats.outliers_influence import (
     variance_inflation_factor as vif,
@@ -14,7 +17,11 @@ __all__ = ["calculate_vif", "tree_feature_selector"]
 def calculate_vif(df: pd.DataFrame, cols: list[str]) -> pd.Series:
     """Return variance inflation factors for numeric columns."""
     arr = df[cols].to_numpy(float)
-    return pd.Series([vif(arr, i) for i in range(arr.shape[1])], index=cols)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', category=RuntimeWarning)
+        with np.errstate(divide='ignore'):
+            vals = [vif(arr, i) for i in range(arr.shape[1])]
+    return pd.Series(vals, index=cols)
 
 
 def tree_feature_selector(

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -1,4 +1,6 @@
 import pandas as pd
+import pytest
+import warnings
 from src.selection import calculate_vif, tree_feature_selector
 
 
@@ -10,6 +12,13 @@ def test_vif_returns_series():
   })
   res = calculate_vif(df, ['a', 'b'])
   assert res.index.tolist() == ['a', 'b']
+
+
+def test_vif_no_warning():
+  df = pd.DataFrame({'a': [1.0, 2.0, 3.0], 'b': [2.0, 4.0, 6.0]})
+  with warnings.catch_warnings(record=True) as w:
+    calculate_vif(df, ['a', 'b'])
+  assert not w
 
 
 def test_tree_selector():


### PR DESCRIPTION
## Summary
- silence divide-by-zero warnings in `calculate_vif`
- ensure VIF helper runs without warnings via unit test
- log new behaviour in NOTES

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684598562b488325b4fd76392f33b129