### PR TITLE
Improve README Kaggle instructions

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -59,3 +59,4 @@ corresponding TODO items.
 
 2025-06-08: Added unit tests for fairness metrics.
 2025-06-08: Wrapped VIF computation in warnings and numpy error state contexts to avoid RuntimeWarning when columns are perfectly collinear.
+2025-06-08: Clarified Kaggle credential setup in README.

--- a/README.md
+++ b/README.md
@@ -36,11 +36,17 @@ pip install -e .
 # If you used conda, activate the environment
 conda activate ml-classification
 
-# Download the Kaggle dataset (needs KAGGLE_USERNAME and KAGGLE_KEY env vars)
+# Provide your Kaggle API token before downloading the dataset.
+# Either place `kaggle.json` under `~/.kaggle/` or export the
+# `KAGGLE_USERNAME` and `KAGGLE_KEY` environment variables:
+#
+#   export KAGGLE_USERNAME=your_username
+#   export KAGGLE_KEY=your_key
+#
+# Download the Kaggle dataset
 python scripts/download_data.py
 
-# The raw CSVs land in `data/raw/` (git-ignored). Make sure your Kaggle
-# credentials are set via environment variables or `~/.kaggle/kaggle.json`.
+# The raw CSVs land in `data/raw/` (git-ignored).
 
 # Train, evaluate and store artefacts in artefacts/
 make train            # run both models


### PR DESCRIPTION
## Summary
- clarify how to supply Kaggle credentials in the Quick-start guide
- note the change in NOTES

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845976eeb7c8325b80050ae833c040a