### PR TITLE
Extend evaluation metrics and CV

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -73,3 +73,4 @@ corresponding TODO items.
 2025-06-18: Added --data-path option to mlcls-train and updated tests.
 2025-06-20: Added CITATION.cff for citation metadata.
 
+2025-06-08: expanded evaluate metrics and CV, added new tests

--- a/tests/test_evaluate_extended.py
+++ b/tests/test_evaluate_extended.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import pandas as pd
+from sklearn.datasets import make_classification
+from sklearn.linear_model import LogisticRegression
+
+from src import dataprep, evaluate
+
+
+def _df() -> pd.DataFrame:
+    x, y = make_classification(n_samples=40, n_features=4, random_state=1)
+    df = pd.DataFrame(x, columns=[f"f{i}" for i in range(x.shape[1])])
+    df["Loan_Status"] = pd.Series(y).map({1: "Y", 0: "N"})
+    return dataprep.clean(df)
+
+
+def test_extended_metrics_and_grid() -> None:
+    df = _df()
+    metrics = evaluate.evaluate_models(df)
+    for col in ["f1", "recall", "specificity", "bal_acc"]:
+        assert col in metrics.columns
+    res, _, _ = evaluate._run_nested(
+        df,
+        "Loan_Status",
+        LogisticRegression(max_iter=1000, solver="liblinear"),
+        {"model__C": [0.3, 1, 3], "model__penalty": ["l1", "l2"]},
+    )
+    assert len(res["estimator"][0].cv_results_["params"]) > 1


### PR DESCRIPTION
## Summary
- enhance evaluation with RepeatedStratifiedKFold and bootstrap fallback
- expand model grids
- compute extra metrics
- test that extended metrics exist and grid search runs

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845b0662d788325821274cbaf5dec43