### PR TITLE
Add oversampling support to training CLI

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -73,3 +73,4 @@ corresponding TODO items.
 2025-06-18: Added --data-path option to mlcls-train and updated tests.
 2025-06-20: Added CITATION.cff for citation metadata.
 
+2025-06-21: Added sampler option to training pipeline and oversampling tests.

--- a/src/models/logreg.py
+++ b/src/models/logreg.py
@@ -6,7 +6,8 @@ import joblib
 import pandas as pd
 from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import roc_auc_score
-from sklearn.pipeline import Pipeline
+from imblearn.base import SamplerMixin
+from imblearn.pipeline import Pipeline
 
 from ..dataprep import clean
 from ..features import FeatureEngineer
@@ -25,17 +26,24 @@ def load_data(path: str | Path = DATA_PATH) -> pd.DataFrame:
     return FeatureEngineer().transform(df)
 
 
-def build_pipeline(cat_cols: list[str], num_cols: list[str]) -> Pipeline:
+def build_pipeline(
+    cat_cols: list[str], num_cols: list[str], sampler: SamplerMixin | None = None
+) -> Pipeline:
     """Create preprocessing and logistic regression pipeline."""
     preproc = build_preprocessor(num_cols, cat_cols)
     model = LogisticRegression(max_iter=1000)
-    return Pipeline([("prep", preproc), ("model", model)])
+    steps = [("prep", preproc)]
+    if sampler is not None:
+        steps.append(("sampler", sampler))
+    steps.append(("model", model))
+    return Pipeline(steps)
 
 
 def train_from_df(
     df: pd.DataFrame,
     target: str = TARGET,
     artefact_path: Path | None = None,
+    sampler: SamplerMixin | None = None,
 ) -> float:
     """Train model on ``df`` and return validation ROC-AUC."""
     train_df, val_df, _ = stratified_split(df, target)
@@ -45,7 +53,7 @@ def train_from_df(
     y_val = val_df[target]
     cat_cols = x_train.select_dtypes(include=["object", "category"]).columns.tolist()
     num_cols = [c for c in x_train.columns if c not in cat_cols]
-    pipe = build_pipeline(cat_cols, num_cols)
+    pipe = build_pipeline(cat_cols, num_cols, sampler)
     pipe.fit(x_train, y_train)
     pred = pipe.predict_proba(x_val)[:, 1]
     auc = roc_auc_score(y_val, pred)
@@ -55,9 +63,13 @@ def train_from_df(
     return auc
 
 
-def main(data_path: str | Path = DATA_PATH) -> None:
+def main(
+    data_path: str | Path = DATA_PATH, sampler: SamplerMixin | None = None
+) -> None:
     df = load_data(data_path)
-    auc = train_from_df(df, artefact_path=Path("artefacts/logreg.joblib"))
+    auc = train_from_df(
+        df, artefact_path=Path("artefacts/logreg.joblib"), sampler=sampler
+    )
     print(f"Validation ROC-AUC: {auc:.3f}")
 
 

--- a/src/train.py
+++ b/src/train.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
+from imblearn.over_sampling import RandomOverSampler, SMOTE, SMOTEN, SMOTENC
+from imblearn.under_sampling import RandomUnderSampler
+from imblearn.combine import SMOTETomek
+
 from .models import logreg, cart
 
 
@@ -22,13 +26,36 @@ def main(args: list[str] | None = None) -> None:
         default=logreg.DATA_PATH,
         help="CSV dataset path",
     )
+    parser.add_argument(
+        "--sampler",
+        choices=[
+            "smote",
+            "smotenc",
+            "smoten",
+            "randomover",
+            "randomunder",
+            "smotetomek",
+        ],
+        default=None,
+        help="optional imbalance sampler",
+    )
     ns = parser.parse_args(args)
     models = ns.model or ["logreg", "cart"]
 
+    sampler_map = {
+        "smote": SMOTE,
+        "smotenc": SMOTENC,
+        "smoten": SMOTEN,
+        "randomover": RandomOverSampler,
+        "randomunder": RandomUnderSampler,
+        "smotetomek": SMOTETomek,
+    }
+    sampler = sampler_map[ns.sampler]() if ns.sampler else None
+
     if "logreg" in models:
-        logreg.main(ns.data_path)
+        logreg.main(ns.data_path, sampler)
     if "cart" in models:
-        cart.main(ns.data_path)
+        cart.main(ns.data_path, sampler)
 
 
 if __name__ == "__main__":

--- a/tests/test_oversampling.py
+++ b/tests/test_oversampling.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+from imblearn.over_sampling import SMOTE
+
+from src.models.logreg import train_from_df as train_logreg
+from src.models.cart import train_from_df as train_cart
+from src.features import FeatureEngineer
+from src import dataprep
+
+
+def _toy_df(n: int = 30) -> pd.DataFrame:
+    rng = np.random.default_rng(1)
+    df = pd.DataFrame(
+        {
+            "income_annum": rng.normal(200_000, 50_000, n),
+            "loan_amount": rng.normal(100_000, 20_000, n),
+            "loan_term": rng.integers(6, 24, n),
+            "cibil_score": rng.integers(600, 750, n),
+            "education": rng.choice(["Graduate", "Not Graduate"], n),
+            "self_employed": rng.choice(["Yes", "No"], n),
+            "residential_assets_value": rng.uniform(50_000, 150_000, n),
+            "commercial_assets_value": rng.uniform(0, 100_000, n),
+            "luxury_assets_value": rng.uniform(0, 50_000, n),
+            "bank_asset_value": rng.uniform(0, 50_000, n),
+            "gender": rng.choice(["M", "F"], n),
+            "married": rng.choice(["Yes", "No"], n),
+            "property_area": rng.choice(["Urban", "Rural", "Semiurban"], n),
+            "no_of_dependents": rng.integers(0, 4, n),
+            "target": rng.integers(0, 2, n),
+        }
+    )
+    return df
+
+
+def test_logreg_sampler() -> None:
+    df = _toy_df()
+    df = dataprep.clean(df)
+    df = FeatureEngineer().transform(df)
+    auc = train_logreg(df, "target", sampler=SMOTE())
+    assert 0 <= auc <= 1
+
+
+def test_cart_sampler() -> None:
+    df = _toy_df()
+    df = dataprep.clean(df)
+    df = FeatureEngineer().transform(df)
+    auc = train_cart(df, "target", sampler=SMOTE())
+    assert 0 <= auc <= 1


### PR DESCRIPTION
## Summary
- support sampler objects in `build_pipeline` for both models
- implement `--sampler` option for `mlcls-train`
- provide SMOTE and friends
- add oversampling tests

## Testing
- `flake8`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845b0647a648325baa87153f7802e20