### PR TITLE
Fix Makefile tabs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@ train-logreg:
 	python -m src.models.logreg
 
 train-cart:
-        python -m src.models.cart
+	python -m src.models.cart
 
 train:
-        python -m src.train
+	python -m src.train
 
 eval:
 	python -m src.evaluate

--- a/NOTES.md
+++ b/NOTES.md
@@ -81,3 +81,4 @@ corresponding TODO items.
 2025-06-22: Cleaned TODO to remove outdated missing-feature notes.
 
 2025-06-08: Removed extra blank lines in src/__init__.py to satisfy flake8.
+2025-06-08: Fixed indentation in train-cart, train, eval commands in Makefile.


### PR DESCRIPTION
## Summary
- ensure Makefile commands use leading TABs for train-cart, train and eval rules
- log this change in NOTES

## Testing
- `black --check .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845bea15e94832596f0210953a1ec55