### PR TITLE
Fix dataset column handling

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -82,3 +82,5 @@ corresponding TODO items.
 
 2025-06-08: Removed extra blank lines in src/__init__.py to satisfy flake8.
 2025-06-08: Fixed indentation in train-cart, train, eval commands in Makefile.
+2025-06-09: Verified Kaggle download and training pipelines. Added lowercase loan_status handling in dataprep.
+2025-06-09: Strip whitespace in dataset columns for evaluation.

--- a/src/dataprep.py
+++ b/src/dataprep.py
@@ -14,8 +14,23 @@ def load_raw(path: str | Path = CSV_PATH) -> pd.DataFrame:
 
 
 def clean(df: pd.DataFrame) -> pd.DataFrame:
-  """Basic cleaning: drop duplicates/NA and normalise target column."""
-  df = df.drop_duplicates().dropna().copy()
-  if 'Loan_Status' in df.columns:
-    df['Loan_Status'] = df['Loan_Status'].map({'Y': 1, 'N': 0}).astype('Int64')
-  return df
+    """Basic cleaning: drop duplicates/NA and normalise target column."""
+    df = df.drop_duplicates().dropna().copy()
+    df.columns = df.columns.str.strip()
+
+    if "loan_status" in df.columns and "Loan_Status" not in df.columns:
+        df = df.rename(columns={"loan_status": "Loan_Status"})
+
+    if "Loan_Status" in df.columns:
+        df["Loan_Status"] = df["Loan_Status"].astype(str).str.strip()
+        mapping = {
+            "Y": 1,
+            "N": 0,
+            "Approved": 1,
+            "Rejected": 0,
+        }
+        df["Loan_Status"] = (
+            df["Loan_Status"].map(mapping).fillna(df["Loan_Status"]).astype("Int64")
+        )
+
+    return df

--- a/tests/test_dataprep.py
+++ b/tests/test_dataprep.py
@@ -14,3 +14,11 @@ def test_clean():
     cleaned = dataprep.clean(df)
     assert cleaned.shape == (2, 2)
     assert set(cleaned["Loan_Status"]) <= {0, 1}
+
+
+def test_clean_lowercase() -> None:
+    df = pd.DataFrame(
+        {"A": [1, 2, 3], "loan_status": ["Approved", "Rejected", "Approved"]}
+    )
+    cleaned = dataprep.clean(df)
+    assert list(cleaned["Loan_Status"]) == [1, 0, 1]


### PR DESCRIPTION
## Summary
- handle lowercase and space-padded `loan_status` values in `dataprep.clean`
- test for lowercase input
- record Kaggle download + training notes

## Testing
- `flake8`
- `black --check .`
- `pytest -q`
- `make eval`

------
https://chatgpt.com/codex/tasks/task_e_6846b54cc6c0832590c0bd245737ddd0