### PR TITLE
Update CI badge

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -84,3 +84,4 @@ corresponding TODO items.
 2025-06-08: Fixed indentation in train-cart, train, eval commands in Makefile.
 2025-06-09: Verified Kaggle download and training pipelines. Added lowercase loan_status handling in dataprep.
 2025-06-09: Strip whitespace in dataset columns for evaluation.
+2025-06-23: Replaced Build & Test badge with GitHub internal badge for private repo.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **A tidy, production-ready re-implementation of my Google Colab notebook for predicting loan approvals with logistic regression and decision-tree pipelines.**
 
-[![Build & Test](https://img.shields.io/github/actions/workflow/status/IvanStarostin1984/ML_classification/ci.yml?branch=main)](../../actions)  
+[![Build & Test](https://github.com/IvanStarostin1984/ML_classification/actions/workflows/ci.yml/badge.svg)](../../actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 ![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue)
 ![ROC-AUC 0.987 ± 0.008](https://img.shields.io/badge/Test ROC–AUC-0.987-±0.008-purple)


### PR DESCRIPTION
## Summary
- use GitHub-hosted workflow badge so it works in a private repo
- log this change in `NOTES.md`

## Testing
- `n/a` (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_6846b80377008325b44b18cf99e1c4ce