### PR TITLE
Add grid search training for logistic regression

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -88,3 +88,4 @@ corresponding TODO items.
 2025-06-23: Added note in README that 'pip install -e .' registers src for import so scripts like python scripts/download_data.py work.
 2025-06-24: README clarifies that `make` is required and lists console script alternatives for Windows.
 
+2025-06-09: Added grid_train_from_df with grid search and tests.

--- a/TODO.md
+++ b/TODO.md
@@ -43,7 +43,7 @@ Inspection of ai_arisha.py reveals several features that were not ported to the 
 
 
 Extensive hyper‑parameter grids
-ai_arisha.py defines larger parameter grids for both logistic regression and decision tree models (e.g. varying C, penalty, class_weight, tree depth, leaf size). The modular code has minimal grids of two values for each model.
+ai_arisha.py defines larger parameter grids for both logistic regression and decision tree models (e.g. varying C, penalty, class_weight, tree depth, leaf size). The logistic grid is now exposed via ``grid_train_from_df`` but the tree model still uses a minimal grid.
 
 Repeated cross‑validation and bootstrap logic
 The original script uses RepeatedStratifiedKFold and falls back to bootstrapping when the minority class is small, recording confidence intervals over folds. The modular code runs a single 3×3 nested CV without bootstrapping.

--- a/src/models/logreg.py
+++ b/src/models/logreg.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 from pathlib import Path
 
 import joblib
+import numpy as np
 import pandas as pd
 from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import roc_auc_score
+from sklearn.model_selection import GridSearchCV, RepeatedStratifiedKFold
 from imblearn.base import SamplerMixin
 from imblearn.pipeline import Pipeline
+from imblearn.over_sampling import SMOTE, SMOTENC
 
 from ..dataprep import clean
 from ..features import FeatureEngineer
@@ -17,6 +20,23 @@ from ..split import stratified_split
 
 DATA_PATH = Path("data/raw/loan_approval_dataset.csv")
 TARGET = "loan_status"
+
+# logistic regression hyper-parameter blocks (sampler added dynamically)
+_LOGREG_PARAM_GRID_BASE = [
+    {
+        "model__solver": ["liblinear"],
+        "model__penalty": ["l1", "l2"],
+        "model__C": np.logspace(-3, 1, 5).tolist(),
+        "model__class_weight": ["balanced", None],
+    },
+    {
+        "model__solver": ["saga"],
+        "model__penalty": ["elasticnet"],
+        "model__l1_ratio": [0.3, 0.7],
+        "model__C": np.logspace(-3, 1, 4).tolist(),
+        "model__class_weight": [None],
+    },
+]
 
 
 def load_data(path: str | Path = DATA_PATH) -> pd.DataFrame:
@@ -60,6 +80,53 @@ def train_from_df(
     if artefact_path:
         artefact_path.parent.mkdir(parents=True, exist_ok=True)
         joblib.dump(pipe, artefact_path)
+    return auc
+
+
+def grid_train_from_df(
+    df: pd.DataFrame,
+    target: str = TARGET,
+    artefact_path: Path | None = None,
+) -> float:
+    """Grid-search logistic regression and return validation ROC-AUC."""
+    train_df, val_df, _ = stratified_split(df, target)
+    x_train = train_df.drop(columns=[target])
+    y_train = train_df[target]
+    x_val = val_df.drop(columns=[target])
+    y_val = val_df[target]
+    cat_cols = x_train.select_dtypes(include=["object", "category"]).columns.tolist()
+    num_cols = [c for c in x_train.columns if c not in cat_cols]
+    cat_mask = [i for i, c in enumerate(x_train.columns) if c in cat_cols]
+    smote_nc = (
+        SMOTENC(categorical_features=cat_mask, random_state=42)
+        if cat_mask
+        else SMOTE(random_state=42)
+    )
+    base_samplers = list(
+        dict.fromkeys(
+            [
+                "passthrough",
+                smote_nc,
+                SMOTE(random_state=42),
+            ]
+        )
+    )
+
+    pipe = build_pipeline(cat_cols, num_cols, sampler="passthrough")
+    param_grid = []
+    for blk in _LOGREG_PARAM_GRID_BASE:
+        new_blk = blk.copy()
+        new_blk["sampler"] = base_samplers.copy()
+        param_grid.append(new_blk)
+
+    cv = RepeatedStratifiedKFold(n_splits=5, n_repeats=3, random_state=42)
+    gs = GridSearchCV(pipe, param_grid, cv=cv, scoring="roc_auc", n_jobs=-1)
+    gs.fit(x_train, y_train)
+    pred = gs.best_estimator_.predict_proba(x_val)[:, 1]
+    auc = roc_auc_score(y_val, pred)
+    if artefact_path:
+        artefact_path.parent.mkdir(parents=True, exist_ok=True)
+        joblib.dump(gs.best_estimator_, artefact_path)
     return auc
 
 

--- a/tests/test_logreg_gridsearch.py
+++ b/tests/test_logreg_gridsearch.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+from sklearn.model_selection import ParameterGrid
+
+from src.models import logreg
+from src.models.logreg import grid_train_from_df
+from src import dataprep
+from src.features import FeatureEngineer
+
+
+def _toy_df(n: int = 50) -> pd.DataFrame:
+    rng = np.random.default_rng(2)
+    df = pd.DataFrame(
+        {
+            "income_annum": rng.normal(200_000, 50_000, n),
+            "loan_amount": rng.normal(100_000, 20_000, n),
+            "loan_term": rng.integers(6, 24, n),
+            "cibil_score": rng.integers(600, 750, n),
+            "education": rng.choice(["Graduate", "Not Graduate"], n),
+            "self_employed": rng.choice(["Yes", "No"], n),
+            "residential_assets_value": rng.uniform(50_000, 150_000, n),
+            "commercial_assets_value": rng.uniform(0, 100_000, n),
+            "luxury_assets_value": rng.uniform(0, 50_000, n),
+            "bank_asset_value": rng.uniform(0, 50_000, n),
+            "gender": rng.choice(["M", "F"], n),
+            "married": rng.choice(["Yes", "No"], n),
+            "property_area": rng.choice(["Urban", "Rural", "Semiurban"], n),
+            "no_of_dependents": rng.integers(0, 4, n),
+            "target": rng.integers(0, 2, n),
+        }
+    )
+    return df
+
+
+def test_grid_train_from_df_runs() -> None:
+    grid = []
+    for blk in logreg._LOGREG_PARAM_GRID_BASE:
+        new_blk = blk.copy()
+        new_blk["sampler"] = ["passthrough", "passthrough"]
+        grid.append(new_blk)
+    assert len(list(ParameterGrid(grid))) > 1
+
+    df = _toy_df()
+    df = dataprep.clean(df)
+    df = FeatureEngineer().transform(df)
+    auc = grid_train_from_df(df, "target")
+    assert 0 <= auc <= 1


### PR DESCRIPTION
## Summary
- extend logistic regression model with grid search via `grid_train_from_df`
- add accompanying test
- log the change in NOTES and update TODO

## Testing
- `flake8`
- `black --check src/models/logreg.py tests/test_logreg_gridsearch.py`
- `PYTHONPATH=$(pwd) pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846c6d856008325a5ad633baace9b77