### PR TITLE
Add evaluation utilities and tests

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -108,3 +108,4 @@ corresponding TODO items.
     ``_zeros`` or ``_vif_prune`` remain unported. Marked the TODO item as
     complete to record this gap.
 
+2025-07-02: Added evaluation_utils with plot_or_load and alias wrappers. Reason: implement new helper API. Decisions: keep wrappers thin for simplicity.

--- a/TODO.md
+++ b/TODO.md
@@ -67,3 +67,4 @@ Oversampling options, probability calibration, feature importance export, extend
 - [x] save best estimator when performing cart grid search
 
 - [x] Verify that each function from ai_arisha.py is represented or intentionally omitted in the src modules (see FUNCTIONS.md).
+- [x] add evaluation_utils helpers for plotting and fairness aliases

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -11,6 +11,7 @@ from .preprocessing import build_preprocessor, safe_transform
 from .selection import calculate_vif, tree_feature_selector
 from .evaluate import evaluate_models
 from .fairness import four_fifths_ratio, youden_threshold
+from .evaluation_utils import plot_or_load, youden_thr, four_fifths
 from .calibration import calibrate_model
 from .feature_importance import logreg_coefficients, tree_feature_importances
 from .manifest import write_manifest
@@ -28,6 +29,9 @@ __all__ = [
     "evaluate_models",
     "four_fifths_ratio",
     "youden_threshold",
+    "plot_or_load",
+    "youden_thr",
+    "four_fifths",
     "calibrate_model",
     "logreg_coefficients",
     "tree_feature_importances",

--- a/src/evaluation_utils.py
+++ b/src/evaluation_utils.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+from .fairness import youden_threshold, four_fifths_ratio
+
+__all__ = ["plot_or_load", "youden_thr", "four_fifths"]
+
+
+def plot_or_load(plot_fn: Callable[[Path], None], path: str | Path) -> Path:
+    """Run ``plot_fn`` to create ``path`` if it doesn't exist."""
+    p = Path(path)
+    if not p.exists():
+        p.parent.mkdir(parents=True, exist_ok=True)
+        plot_fn(p)
+    return p
+
+
+def youden_thr(estimator, X, y) -> float:
+    """Return threshold maximising TPR minus FPR."""
+    return youden_threshold(estimator, X, y)
+
+
+def four_fifths(estimator, X, y, group_col: str, thr: float) -> float:
+    """Return four-fifths ratio for ``group_col`` at ``thr``."""
+    return four_fifths_ratio(estimator, X, y, group_col, thr)

--- a/tests/test_evaluation_utils.py
+++ b/tests/test_evaluation_utils.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+
+from src.evaluation_utils import plot_or_load, youden_thr, four_fifths
+from src.fairness import youden_threshold, four_fifths_ratio
+
+
+def _dummy_plot(path):
+    plt.figure()
+    plt.plot([0, 1], [0, 1])
+    plt.savefig(path)
+    plt.close()
+
+
+def test_plot_or_load(tmp_path):
+    fp = tmp_path / "plot.png"
+    calls = []
+
+    def _plot(p):
+        calls.append(1)
+        _dummy_plot(p)
+
+    out = plot_or_load(_plot, fp)
+    assert out == fp
+    assert fp.exists()
+    assert len(calls) == 1
+
+    out = plot_or_load(_plot, fp)
+    assert out == fp
+    assert len(calls) == 1
+
+
+def test_alias_helpers():
+    X = pd.DataFrame({"a": [0, 1, 0, 1], "g": [0, 0, 0, 0]})
+    y = pd.Series([0, 1, 0, 1])
+    model = LogisticRegression().fit(X, y)
+    thr = youden_thr(model, X, y)
+    assert thr == youden_threshold(model, X, y)
+    ratio = four_fifths(model, X, y, "g", thr)
+    assert ratio == four_fifths_ratio(model, X, y, "g", thr)


### PR DESCRIPTION
## Summary
- add new helpers in `evaluation_utils` for caching plots and aliasing fairness tools
- export helpers from package init
- test the helpers
- document work in NOTES and update TODO

## Testing
- `black --check src tests`
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846e8cb75308325b99b037076b61fca