### PR TITLE
Fix vif_prune for small or collinear inputs

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -124,3 +124,4 @@ corresponding TODO items.
 2025-07-05: Added TODO bullet for missing random_split, time_split and set_seeds helper. Reason: these functions remain absent from src compared with the original notebook.
 2025-06-10: Clarified NOTES about reporting utilities in src/reporting.py when summarising ported functions. Reason: correct earlier statement. Decisions: emphasised presence of flatten_cv and others.
 2025-07-05: Added TODOs to port notebook metrics helpers (eval_at, eval_metrics, show_metrics, folds_df) into a new metrics module. Reason: these functions come from ai_arisha.py and would aid reproducibility.
+2025-07-06: Fixed vif_prune to skip VIF calculation when fewer than two columns remain and stop on infinite VIF with two columns. Reason: avoid singular matrix errors.

--- a/TODO.md
+++ b/TODO.md
@@ -89,6 +89,7 @@ Oversampling options, probability calibration, feature importance export, extend
 
 - [x] add Makefile test target to run pytest
 - [x] port `_vif_prune` as `vif_prune` in `src/selection.py` with unit tests
+- [x] VIF pruning handles singular matrices
 
 
 

--- a/src/selection.py
+++ b/src/selection.py
@@ -31,9 +31,17 @@ def vif_prune(
 
     cols = list(cols)
     while True:
+        if len(cols) < 2:
+            return cols, pd.Series([np.nan] * len(cols), index=cols)
+
         vifs = calculate_vif(df, cols)
-        if vifs.max() <= cap or len(cols) < 2:
+
+        if len(cols) == 2 and not np.isfinite(vifs).all():
             return cols, vifs
+
+        if vifs.max() <= cap:
+            return cols, vifs
+
         cols.remove(vifs.idxmax())
 
 

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import numpy as np
 import warnings
 from src.selection import calculate_vif, tree_feature_selector, vif_prune
 
@@ -47,3 +48,18 @@ def test_vif_prune_no_drop_when_below_cap():
     cols, vifs = vif_prune(df, ["x", "y"], cap=100)
     assert cols == ["x", "y"]
     assert list(vifs.index) == ["x", "y"]
+
+
+def test_vif_prune_single_column():
+    df = pd.DataFrame({"x": [1.0, 2.0, 3.0]})
+    cols, vifs = vif_prune(df, ["x"], cap=5)
+    assert cols == ["x"]
+    assert vifs.isna().all()
+
+
+def test_vif_prune_two_infinite_vifs():
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [1, 2, 3]})
+    cols, vifs = vif_prune(df, ["a", "b"], cap=1000)
+    assert cols == ["a", "b"]
+    assert vifs.index.tolist() == ["a", "b"]
+    assert not vifs.replace([np.inf, -np.inf], np.nan).notna().all()


### PR DESCRIPTION
## Summary
- refine `vif_prune` to cope with single columns and infinite VIFs
- add unit tests covering single and perfectly correlated columns
- document the bug fix in NOTES and mark TODO about VIF pruning

## Testing
- `flake8`
- `black --check .`
- `PYTHONPATH=$(pwd) pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847fc77b3c88325a01f1846897cd752