### PR TITLE
Fix markdown formatting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,76 +1,86 @@
 # Contributor Guidelines for ML_classification
 
-This repository hosts ML classifier (trees and logistic classifier).  Follow these rules when adding or updating code.
+This repository hosts ML classifier (trees and logistic classifier). Follow
+these rules when adding or updating code.
 
-Your job is to migrate Google Colab notebook ai_arisha.py to several classes github repo in line with README.md to showcase my work.
+Your job is to migrate Google Colab notebook ai_arisha.py to several classes
+github repo in line with README.md to showcase my work.
 
-The style rules apply to new code under `src/` and tests, while `ai_arisha.py` is kept as-is for reference
+The style rules apply to new code under `src/` and tests, while `ai_arisha.py`
+is kept as-is for reference
 
-TODO.md, NOTES.md AGENTS.md may be not perfectly aligned with current project status. Always recheck in actual code.
-**Distinct-files rule**:  
-   1. Every concurrent task must confine its edits to a **unique list of code or data files**.  
-   2. *Shared exceptions*: any task may append (never rewrite) the markdown logs `NOTES.md`, `TODO.md`, and this `AGENTS.md`.  
-   3. If two or more open PRs would touch the same non-markdown file, cancel or re-scope one of them before continuing.
+TODO.md, NOTES.md AGENTS.md may be not perfectly aligned with current project
+status. Always recheck in actual code.
+**Distinct-files rule**:
 
-# Important — Not authoritative:
+1. Every concurrent task must confine its edits to a **unique list of code or
+data files**.
+2. _Shared exceptions_: any task may append (never rewrite) the markdown logs
+`NOTES.md`, `TODO.md`, and this `AGENTS.md`.
+3. If two or more open PRs would touch the same non-markdown file, cancel or
+re-scope one of them before continuing.
+
+## Important — Not authoritative
+
 1. This file is only a quick-start contributor guide.
 2. Your job is to adapt google colab python code to Github.
 3. KAGGLE_USERNAME, KAGGLE_KEY are in secrets
 4. Never commit downloaded Kaggle data or personal API keys
-5. With *ANY* pull request add data to NOTES.md to shortly reflect on work done in this pull request. Always! 
+5. With _ANY_ pull request add data to NOTES.md to shortly reflect on work done
+in this pull request. Always!
 
-# Project structure
+## Project structure
+
 ML_classification/
 ├─ .github/
-│   └─ workflows/
-│       └─ ci.yml                   # lint + pytest on Python 3.10
-├─ ai_arisha.py                     # original Colab / legacy script
-├─ AGENTS.md                        # design / architecture notes
+│ └─ workflows/
+│ └─ ci.yml # lint + pytest on Python 3.10
+├─ ai_arisha.py # original Colab / legacy script
+├─ AGENTS.md # design / architecture notes
 ├─ data/
-│   └─ README.md                    # Kaggle‐licence notice & instructions
+│ └─ README.md # Kaggle‐licence notice & instructions
 ├─ notebooks/
-│   └─ README.md                    # slim Colab/Binder demo stub
+│ └─ README.md # slim Colab/Binder demo stub
 ├─ scripts/
-│   └─ download_data.py             # pulls dataset via Kaggle API
+│ └─ download_data.py # pulls dataset via Kaggle API
 ├─ src/
-│   ├─ __init__.py
-│   ├─ dataprep.py                  # load / clean raw data
-│   ├─ features.py                  # FeatureEngineer class
-│   ├─ diagnostics.py               # χ² tests, corr heat-map, etc.
-│   ├─ preprocessing.py             # ColumnTransformers
-│   ├─ selection.py                 # VIF, RFE, tree selector
-│   ├─ split.py                     # stratified train/test logic
-│   ├─ evaluate.py                  # nested CV + fairness metrics
-│   ├─ fairness.py                  # fairness helpers
-│   ├─ metrics.py                   # metric utilities from notebook
-│   ├─ train.py                     # orchestrates pipelines
-│   └─ models/
-│       ├─ __init__.py
-│       ├─ logreg.py                # LR training / eval pipeline
-│       └─ cart.py                  # Decision-Tree pipeline
+│ ├─ **init**.py
+│ ├─ dataprep.py # load / clean raw data
+│ ├─ features.py # FeatureEngineer class
+│ ├─ diagnostics.py # χ² tests, corr heat-map, etc.
+│ ├─ preprocessing.py # ColumnTransformers
+│ ├─ selection.py # VIF, RFE, tree selector
+│ ├─ split.py # stratified train/test logic
+│ ├─ evaluate.py # nested CV + fairness metrics
+│ ├─ fairness.py # fairness helpers
+│ ├─ metrics.py # metric utilities from notebook
+│ ├─ train.py # orchestrates pipelines
+│ └─ models/
+│ ├─ **init**.py
+│ ├─ logreg.py # LR training / eval pipeline
+│ └─ cart.py # Decision-Tree pipeline
 ├─ tests/
-│   ├─ test_dataprep.py             # unit tests for data loading
-│   ├─ test_features.py             # unit tests for feature engineering
-│   ├─ test_models.py               # unit tests for modelling pipelines
-│   ├─ test_smoke.py                # CI sanity import check
-│   ├─ test_download_data.py        # tests the data download script
-│   ├─ test_preprocessing.py        # preprocessing pipeline tests
-│   ├─ test_selection.py            # feature selection helpers
-│   ├─ test_diagnostics.py          # diagnostic utilities
-│   ├─ test_evaluate.py             # tests for the evaluation CLI
-│   └─ test_fairness.py             # tests for fairness metrics
-│   └─ test_metrics.py              # unit tests for metric helpers
-├─ environment.yml                  # Conda spec (Python ≥ 3.10)
-├─ requirements.txt                 # pip fallback
-├─ Dockerfile                       # reproducible container build
-├─ Makefile                         # one-command workflow (`make train`)
-├─ .gitignore                       # excludes data, artefacts, secrets
-├─ LICENSE                          # MIT License
-└─ README.md                        # badges, quick-start, results, contact
-
-
+│ ├─ test_dataprep.py # unit tests for data loading
+│ ├─ test_features.py # unit tests for feature engineering
+│ ├─ test_models.py # unit tests for modelling pipelines
+│ ├─ test_smoke.py # CI sanity import check
+│ ├─ test_download_data.py # tests the data download script
+│ ├─ test_preprocessing.py # preprocessing pipeline tests
+│ ├─ test_selection.py # feature selection helpers
+│ ├─ test_diagnostics.py # diagnostic utilities
+│ ├─ test_evaluate.py # tests for the evaluation CLI
+│ └─ test_fairness.py # tests for fairness metrics
+│ └─ test_metrics.py # unit tests for metric helpers
+├─ environment.yml # Conda spec (Python ≥ 3.10)
+├─ requirements.txt # pip fallback
+├─ Dockerfile # reproducible container build
+├─ Makefile # one-command workflow (`make train`)
+├─ .gitignore # excludes data, artefacts, secrets
+├─ LICENSE # MIT License
+└─ README.md # badges, quick-start, results, contact
 
 ## Coding Standards
+
 - One domain concept per file; no cyclic imports.
 - Functions should stay under 20 lines with at most 2 nesting levels.
 - Favour composition over inheritance and keep variables scoped tightly.
@@ -78,31 +88,39 @@ ML_classification/
 - Use 4‑space indentation, single quotes and end files with a newline.
 - Document each public API/function with a doc comment.
 
-
 ## Testing & CI
+
 - The GitHub Actions workflow (`.github/workflows/ci.yml`) runs `flake8`,
   `black --check .` and `pytest` on Python&nbsp;3.10.
 - Run these commands locally before committing to ensure your code passes the
-  same checks. Use `make test` to run the full pytest suite with the correct `PYTHONPATH`.
+  same checks. Use `make test` to run the full pytest suite with the correct
+`PYTHONPATH`.
 - Black uses a line length of **88** as configured in `pyproject.toml`.
 
 ## Contributing Workflow
+
 - **Fork** then branch off `main` using the pattern `feat/<topic>`.
 - **Ensure local tests pass** before opening a PR.
 - **Each PR requires at least one reviewer.**
-- with *every commit* reflect in **NOTES.md** on work done in a short lean way to track work.
+- with _every commit_ reflect in **NOTES.md** on work done in a short lean way
+to track work.
 
-Read `NOTES.md` and `TODO.md` to understand the current stage, past decisions, and open questions tied to the spec.
+Read `NOTES.md` and `TODO.md` to understand the current stage, past decisions,
+and open questions tied to the spec.
 
-Refer to `README.md` and full documentation in `docs/` for further details on features and architecture.
+Refer to `README.md` and full documentation in `docs/` for further details on
+features and architecture.
 
 ## Migration tracking
 
 Two markdown files at the repository root help coordinate the refactor.
 
-- **TODO.md** – complete list of tasks required to move the legacy `ai_arisha.py` notebook into the modular project layout above.
+- **TODO.md** – complete list of tasks required to move the legacy
+`ai_arisha.py` notebook into the modular project layout above.
 - **NOTES.md** – running log that explains what was done and how.
 
-Contributors must keep `TODO.md` up to date with remaining work and record completed items in `NOTES.md`.
+Contributors must keep `TODO.md` up to date with remaining work and record
+completed items in `NOTES.md`.
 
-- **FUNCTIONS.md** – reference list of notebook functions. Ensure each is implemented or intentionally skipped. Log skipped ones in NOTES.md.
+- **FUNCTIONS.md** – reference list of notebook functions. Ensure each is
+implemented or intentionally skipped. Log skipped ones in NOTES.md.

--- a/FUNCTIONS.md
+++ b/FUNCTIONS.md
@@ -1,6 +1,7 @@
 # Functions in ai_arisha.py
 
-This list captures every function defined in the legacy Colab script. Use it when verifying that the modular `src/` package implements equivalent behaviour.
+This list captures every function defined in the legacy Colab script. Use it
+when verifying that the modular `src/` package implements equivalent behaviour.
 
 - `_zeros()` – return Series of zeros aligned to `df_fe` index.
 - `_fmt_p(p, thr=1e-6)` – format p-value; shows `<thr` for tiny values.
@@ -8,32 +9,43 @@ This list captures every function defined in the legacy Colab script. Use it whe
 - `_need_exact(exp)` – decide whether chi² test needs Monte Carlo.
 - `_cramers_v(chi2, tbl)` – Cramer’s V effect size for contingency tables.
 - `_cochran_armitage(ct)` – Cochran–Armitage trend test for 2×k tables.
-- `_safe_chi2(ct, need_mc, rng)` – chi² test with Monte Carlo and 0.5 adjustment fallback.
+- `_safe_chi2(ct, need_mc, rng)` – chi² test with Monte Carlo and 0.5
+adjustment fallback.
 - `_dedup(old, new)` – merge pairs and drop duplicates regardless of order.
 - `_is_binary_numeric(series)` – check if numeric column only contains 0/1.
-- `safe_transform(preprocessor, X_new, copy=True)` – apply fitted ColumnTransformer dropping unseen columns.
-- `_vif_prune(cols, cap)` – iteratively drop columns with highest VIF until below cap.
+- `safe_transform(preprocessor, X_new, copy=True)` – apply fitted
+ColumnTransformer dropping unseen columns.
+- `_vif_prune(cols, cap)` – iteratively drop columns with highest VIF until
+below cap.
 - `_random_split(test_frac)` – stratified random train/test split.
 - `_time_split(test_frac)` – time-based train/test split using `DATE_COL`.
 - `set_seeds(s=SEED)` – seed Python, NumPy and PYTHONHASHSEED.
 - `lr_steps(samp)` – pipeline steps order for logistic regression.
 - `tree_steps(samp)` – pipeline steps order for decision tree.
-- `run_gs(name, steps, estimator, grid)` – run GridSearchCV and report best ROC-AUC.
+- `run_gs(name, steps, estimator, grid)` – run GridSearchCV and report best
+ROC-AUC.
 - `show_metrics(lbl, y_true, y_prob, y_hat)` – print test-set metrics summary.
 - `_is_binary(series)` – helper to filter out pure binary numeric features.
-- `_num_block(cols, scaler)` – return (pipeline, columns) for numeric scaler block.
+- `_num_block(cols, scaler)` – return (pipeline, columns) for numeric scaler
+block.
 - `make_preprocessor(include_cont)` – build ColumnTransformer for LR or tree.
 - `_prefix(label)` – extract prefix from feature name.
-- `_scaled_matrix(prep)` – transform full dataset and return matrix with feature names.
-- `_check_mu_sigma(mat, idx, tol_mu=1e-3, tol_sd=1e-2)` – verify scaled columns have mean≈0 and sd≈1.
-- `validate_prep(prep, name, check_scale=True)` – run NaN/scale checks on transformer.
+- `_scaled_matrix(prep)` – transform full dataset and return matrix with
+feature names.
+- `_check_mu_sigma(mat, idx, tol_mu=1e-3, tol_sd=1e-2)` – verify scaled
+columns have mean≈0 and sd≈1.
+- `validate_prep(prep, name, check_scale=True)` – run NaN/scale checks on
+transformer.
 - `_conf(label, yhat)` – print confusion matrix and metrics for threshold.
 - `_group_metrics(col)` – compute group-wise TPR for fairness audit.
-- `build_outer_iter(y)` – return outer CV splits or bootstrap when minority<10.
-- `nested_cv(pipe, grid, label)` – run nested cross-validation and report scores.
+- `build_outer_iter(y)` – return outer CV splits or bootstrap when
+minority<10.
+- `nested_cv(pipe, grid, label)` – run nested cross-validation and report
+scores.
 - `folds_df(res, mdl)` – helper to turn CV results into a tidy DataFrame.
 - `youden_thr(est, X, y)` – compute optimal Youden J threshold from ROC curve.
-- `four_fifths(est, X, y, col, thr)` – inner function used to compute 4/5ths ratio.
+- `four_fifths(est, X, y, col, thr)` – inner function used to compute 4/5ths
+ratio.
 - `shasum(fp)` – short SHA-256 digest of file bytes.
 - `sha256(path)` – full SHA-256 digest of file bytes.
 - `save_folds(tag, cv)` – save fold indices produced by CV iterator.
@@ -41,19 +53,24 @@ This list captures every function defined in the legacy Colab script. Use it whe
 - `_sha(fp)` – short SHA-256 digest; defined in multiple cells.
 - `sha(fp)` – same as above but using pathlib.Path.
 - `eval_at(th)` – compute test metrics at given probability threshold.
-- `eval_metrics(y_true, y_prob, y_pred, suffix)` – return dict of performance metrics.
-- `plot_or_load(fname, plot_fn)` – reuse saved plot if available else generate.
+- `eval_metrics(y_true, y_prob, y_pred, suffix)` – return dict of performance
+metrics.
+- `plot_or_load(fname, plot_fn)` – reuse saved plot if available else
+generate.
 - `main()` – collect various artifacts into `report_artifacts/`.
   - `find_path(name)` – search artifact directories for file.
-  - `read_latest_glob(pattern, dirs=(ART, PLOTS, ROOT))` – return most recent match.
+  - `read_latest_glob(pattern, dirs=(ART, PLOTS, ROOT))` – return most recent
+match.
   - `write_section(f, title, reader_fn)` – helper for report table sections.
   - `flatten_cv(path)` – collapse multi-index CV CSV to two-row table.
   - `flatten_metrics(md)` – flatten nested metric JSON.
   - `dump_dataset_overview(ff)` – write dataset overview text.
   - `dump_lr_params(ff)` – report best logistic regression parameters.
   - `dump_cart_params(ff)` – report best CART parameters.
-  - `dump_feature_counts(ff)` – report engineered feature counts from registry.
+  - `dump_feature_counts(ff)` – report engineered feature counts from
+registry.
   - `dump_corr_top10(ff)` – show top absolute correlations.
-  - `dump_dropped_twins(ff)` – list numeric twins removed due to high correlation.
+  - `dump_dropped_twins(ff)` – list numeric twins removed due to high
+correlation.
   - `dump_skew_profile(ff)` – summarize skewness profile of numeric features.
   - `dump_cart_overfit(ff)` – compare CART CV vs test ROC AUC.

--- a/NOTES.md
+++ b/NOTES.md
@@ -4,8 +4,6 @@ Current commit: `c907c0b`.
 2025-06-18: Evaluation and fairness modules are in place with passing tests and
 README instructions describing the workflow.
 
-
-
 The modular refactor is nearly complete. Core helpers and model pipelines live
 under `src/` with corresponding tests and an automated GitHub Actions workflow.
 `make train` now runs the training pipelines, though the README still states
@@ -20,123 +18,214 @@ It also mixes data cleaning, feature engineering and model training in one file.
 The notebook remains for reference and all modular helpers and CI are now in
 place.
 
-
-2025-04-30: Added environment.yml, requirements.txt, Dockerfile, Makefile, .gitignore and LICENSE to start project skeleton.
-2025-06-08: Set up CI workflow and created src/, scripts/ and tests skeletons with a smoke test.
+2025-04-30: Added environment.yml, requirements.txt, Dockerfile, Makefile,
+.gitignore and LICENSE to start project skeleton.
+2025-06-08: Set up CI workflow and created src/, scripts/ and tests skeletons
+with a smoke test.
 2025-06-08: Added smoke test importing src and scripts skeleton modules.
 2025-06-09: Added kaggle, flake8, black and pytest to environment files for CI.
-2025-06-08: Updated README repository layout section to match existing folders and note that model modules are missing, so make train fails.
+2025-06-08: Updated README repository layout section to match existing folders
+and note that model modules are missing, so make train fails.
 2025-06-08: Marked directory creation as complete in TODO and noted CI workflow.
 2025-06-08: Introduced FeatureEngineer class and helper modules with unit tests.
 2025-06-08: Added dataset handling instructions and conda activation notes to
 README. Documented notebook usage in `notebooks/README.md` and checked off the
 corresponding TODO items.
-2025-06-10: Implemented Kaggle download script with env auth, added dataprep module and unit tests.
-2025-06-10: Added train/eval modules for logistic regression and decision tree with stratified split utility. Updated Makefile, Dockerfile, README and added basic model tests.
+2025-06-10: Implemented Kaggle download script with env auth, added dataprep
+module and unit tests.
+2025-06-10: Added train/eval modules for logistic regression and decision tree
+with stratified split utility. Updated Makefile, Dockerfile, README and added
+basic model tests.
 2025-06-10: Removed unused numpy imports from diagnostics and selection modules.
 2025-06-08: Reformatted tree_feature_selector arguments to multiple lines.
 2025-06-11: Cleaned flake8 warnings in features.py and split long lines.
 2025-06-08: Standardised df_fe.columns block indentation in features.py.
 2025-06-08: Removed sys.path modification from several test files.
-2025-06-08: Cleaned unused imports, tweaked features formatting and removed sys.path hacking from tests.
-2025-06-12: Updated TODO progress and revised project overview for commit 354c4fc.
-2025-06-12: Updated migration notes to reflect commit 354c4fc and mention completed src modules, tests and CI.
-2025-06-08: Updated AGENTS.md project structure tests section to list module unit tests.
-2025-06-08: Marked tasks complete in TODO and expanded migration notes for commit 536978c.
-2025-06-08: Rewrote TODO introduction to reference dbd5184 and note that modular code, tests and CI now exist.
-2025-06-13: Updated AGENTS.md to list all tests and clarify 4-space indentation standard.
+2025-06-08: Cleaned unused imports, tweaked features formatting and removed
+sys.path hacking from tests.
+2025-06-12: Updated TODO progress and revised project overview for commit
+354c4fc.
+2025-06-12: Updated migration notes to reflect commit 354c4fc and mention
+completed src modules, tests and CI.
+2025-06-08: Updated AGENTS.md project structure tests section to list module
+unit tests.
+2025-06-08: Marked tasks complete in TODO and expanded migration notes for
+commit 536978c.
+2025-06-08: Rewrote TODO introduction to reference dbd5184 and note that
+modular code, tests and CI now exist.
+2025-06-13: Updated AGENTS.md to list all tests and clarify 4-space indentation
+standard.
 2025-06-14: Marked README update as complete in TODO.
-2025-06-14: Updated README to remove missing-modules note and confirm the migration is complete.
-2025-06-14: Updated README to remove missing-modules note and confirm the migration is complete.
-2025-06-08: Removed obsolete README statements about missing model pipelines and noted make train runs both models.
+2025-06-14: Updated README to remove missing-modules note and confirm the
+migration is complete.
+2025-06-14: Updated README to remove missing-modules note and confirm the
+migration is complete.
+2025-06-08: Removed obsolete README statements about missing model pipelines
+and noted make train runs both models.
 2025-06-14: Renamed project structure heading in AGENTS.md.
 2025-06-08: Refreshed README repository layout and checked TODO item.
 2025-06-08: Adjusted CI workflow to invoke pytest via python -m.
-2025-06-15: Added PYTHONPATH env var in CI to fix ModuleNotFoundError during tests.
+2025-06-15: Added PYTHONPATH env var in CI to fix ModuleNotFoundError during
+tests.
 2025-06-16: Added evaluate.py with nested CV and fairness metrics plus tests.
-2025-06-16: Added make eval target and expanded README with evaluation instructions and fairness guidance.
+2025-06-16: Added make eval target and expanded README with evaluation
+instructions and fairness guidance.
 2025-06-08: integrated FeatureEngineer into model pipelines and updated tests.
 2025-06-08: Added CLI main entry in evaluate.py and updated tests and README.
-2025-06-08: Added project metadata in pyproject.toml and exposed src as installable package. README now documents 'pip install -e .' for development.
-2025-06-08: Added src/train.py CLI orchestrating both models and updated Makefile to use it.
+2025-06-08: Added project metadata in pyproject.toml and exposed src as
+installable package. README now documents 'pip install -e .' for development.
+2025-06-08: Added src/train.py CLI orchestrating both models and updated
+Makefile to use it.
 2025-06-08: Added unit tests for fairness metrics.
-2025-06-08: Wrapped VIF computation in warnings and numpy error state contexts to avoid RuntimeWarning when columns are perfectly collinear.
+2025-06-08: Wrapped VIF computation in warnings and numpy error state contexts
+to avoid RuntimeWarning when columns are perfectly collinear.
 2025-06-08: Clarified Kaggle credential setup in README.
-2025-06-17: Updated TODO intro to mark migration complete and added evaluation/fairness checklist item.
-2025-06-08: Documented evaluate/train/fairness modules and tests in AGENTS.md directory tree.
+2025-06-17: Updated TODO intro to mark migration complete and added
+evaluation/fairness checklist item.
+2025-06-08: Documented evaluate/train/fairness modules and tests in AGENTS.md
+directory tree.
 2025-06-18: Cleaned tests and formatted selection/train modules.
-2025-06-08: Expanded Testing & CI guidelines in AGENTS.md to describe flake8, black, pytest workflow.
-2025-06-18: documented new mlcls-* console scripts and usage.
-2025-06-08: Updated download_data to check CSV existence before using Kaggle API and expanded tests.
+2025-06-08: Expanded Testing & CI guidelines in AGENTS.md to describe flake8,
+black, pytest workflow.
+2025-06-18: documented new mlcls-\* console scripts and usage.
+2025-06-08: Updated download_data to check CSV existence before using Kaggle
+API and expanded tests.
 2025-06-08: Added console script entrypoints and tests invoking them.
-2025-06-08: refactored FeatureEngineer.transform into helper methods to meet function length rule. Added docstrings and updated tests. Black and pytest fail due to pyproject parsing error.
+2025-06-08: refactored FeatureEngineer.transform into helper methods to meet
+function length rule. Added docstrings and updated tests. Black and pytest fail
+due to pyproject parsing error.
 2025-06-18: Added --data-path option to mlcls-train and updated tests.
 2025-06-20: Added CITATION.cff for citation metadata.
 2025-06-21: Added plotting helpers and manifest writer with tests.
 2025-06-08: expanded evaluate metrics and CV, added new tests
-2025-06-21: Added calibration module with CLI and tests for model probability calibration.
-2025-06-08: added feature_importance module exporting logistic coefficients and tree importances with tests.
+2025-06-21: Added calibration module with CLI and tests for model probability
+calibration.
+2025-06-08: added feature_importance module exporting logistic coefficients and
+tree importances with tests.
 2025-06-21: Added sampler option to training pipeline and oversampling tests.
-2025-06-22: Documented sampler CLI, calibration command, feature-importance outputs and manifest in README.
+2025-06-22: Documented sampler CLI, calibration command, feature-importance
+outputs and manifest in README.
 2025-06-22: Cleaned TODO to remove outdated missing-feature notes.
-2025-06-08: Removed extra blank lines in src/__init__.py to satisfy flake8.
+2025-06-08: Removed extra blank lines in src/**init**.py to satisfy flake8.
 2025-06-08: Fixed indentation in train-cart, train, eval commands in Makefile.
-2025-06-09: Verified Kaggle download and training pipelines. Added lowercase loan_status handling in dataprep.
+2025-06-09: Verified Kaggle download and training pipelines. Added lowercase
+loan_status handling in dataprep.
 2025-06-09: Strip whitespace in dataset columns for evaluation.
-2025-06-23: Replaced Build & Test badge with GitHub internal badge for private repo.
+2025-06-23: Replaced Build & Test badge with GitHub internal badge for private
+repo.
 2025-06-23: download_data warns when src package is missing and tests cover it.
-2025-06-23: Added note in README that 'pip install -e .' registers src for import so scripts like python scripts/download_data.py work.
-2025-06-24: README clarifies that `make` is required and lists console script alternatives for Windows.
-2025-06-09: Added grid_train_from_df using GridSearchCV with repeated CV and unit test for parameter grid.
+2025-06-23: Added note in README that 'pip install -e .' registers src for
+import so scripts like python scripts/download_data.py work.
+2025-06-24: README clarifies that `make` is required and lists console script
+alternatives for Windows.
+2025-06-09: Added grid_train_from_df using GridSearchCV with repeated CV and
+unit test for parameter grid.
 2025-06-09: Added grid_train_from_df with grid search and tests.
-2025-06-25: Documented --grid-search option for exhaustive cross-validation and added TODO bullet.
+2025-06-25: Documented --grid-search option for exhaustive cross-validation and
+added TODO bullet.
 2025-06-09: Added grid-search flag to mlcls-train and tests.
 2025-06-09: Added grid-search flag to mlcls-train and tests.
-2025-06-25: Cleaned logreg.grid_train_from_df to use RepeatedStratifiedKFold and removed duplicate docstring.
-2025-06-09: Fixed stray parameter block in cart.grid_train_from_df; function now returns fitted GridSearchCV.
+2025-06-25: Cleaned logreg.grid_train_from_df to use RepeatedStratifiedKFold
+and removed duplicate docstring.
+2025-06-09: Fixed stray parameter block in cart.grid_train_from_df; function
+now returns fitted GridSearchCV.
 2025-06-24: Marked TODO item clarifying Makefile usage as done.
 2025-06-09: Documented grid-search flag and dataset size in README.
 2025-06-09: Verified grid_train_from_df header and removed stray blank line.
 2025-06-09: mlcls-train now prints best cart grid-search score.
-2025-06-09: Added FUNCTIONS.md summarising all functions from ai_arisha.py for verification.
-2025-06-27: Clarified README that grid search runs via `mlcls-train -g` and removed
+2025-06-09: Added FUNCTIONS.md summarising all functions from ai_arisha.py for
+verification.
+2025-06-27: Clarified README that grid search runs via `mlcls-train -g` and
+removed
 `mlcls-eval --grid-search` examples.
-2025-06-30: cart.grid_train_from_df can now save the best estimator via new artefact_path argument and tests cover file output.
-2025-07-01: Verified function coverage from ai_arisha.py using FUNCTIONS.md. Besides
-    ``safe_transform`` and the fairness helpers ``youden_threshold`` and
-    ``four_fifths_ratio``, reporting utilities like ``find_path`` and ``write_section``,
-    along with ``flatten_cv`` and ``flatten_metrics`` live in ``src/reporting.py``.
-    All other utilities such as ``_zeros`` or ``_vif_prune`` remain unported.
-    Marked the TODO item as complete to record this gap.
+2025-06-30: cart.grid_train_from_df can now save the best estimator via new
+artefact_path argument and tests cover file output.
+2025-07-01: Verified function coverage from ai_arisha.py using FUNCTIONS.md.
+Besides
+`safe_transform` and the fairness helpers `youden_threshold` and
+`four_fifths_ratio`, reporting utilities like `find_path` and `write_section`,
+along with `flatten_cv` and `flatten_metrics` live in `src/reporting.py`.
+All other utilities such as `_zeros` or `_vif_prune` remain unported.
+Marked the TODO item as complete to record this gap.
 
-2025-06-09: added reporting module with helpers to assemble report and tests for flatten_cv and flatten_metrics.
-2025-07-02: Added evaluation_utils with plot_or_load and alias wrappers. Reason: implement new helper API. Decisions: keep wrappers thin for simplicity.
-2025-07-03: added tests for split.stratified_split verifying split lengths, stratification and index reset. Reason: cover TODO bullet.
-2025-07-03: Added safe_transform input validation tests for type errors and extra-column warnings as per TODO. Reason: improve preprocessing robustness.
-2025-07-03: Added CLI sampler integration test verifying mlcls-train works with SMOTE and prints ROC-AUC. Reason: extend CLI coverage for sampler option.
-2025-06-09: expanded FeatureEngineer tests for column normalisation, asset totals and risk flags. Reason: improve coverage per TODO. Decisions: use pytest.warns for missing asset warnings.
-2025-07-03: Added calibration tests for isotonic option and invalid method validation. Reason: strengthen coverage. Decisions: check `calibrated_classifiers_` attribute and expect ValueError for bad method.
-2025-07-03: Added make test target for simplified testing via pytest. Updated docs and guidelines.
-2025-07-04: Marked TODO item for Makefile test target as done and fixed Makefile tabs. 'make test' now invokes pytest correctly.
-2025-07-04: Marked TODO bullet for Makefile test target as completed. Reason: target already in Makefile.
-2025-07-05: Implemented `vif_prune` for iterative VIF pruning with tests and recorded TODO entry. Reason: port missing helper from ai_arisha.py.
-2025-07-05: Added TODO bullet listing missing statistical diagnostics from FUNCTIONS.md. Reason: document unported helpers for future diagnostics_stats module.
-2025-07-05: Added TODO bullet for missing random_split, time_split and set_seeds helper. Reason: these functions remain absent from src compared with the original notebook.
-2025-06-10: Clarified NOTES about reporting utilities in src/reporting.py when summarising ported functions. Reason: correct earlier statement. Decisions: emphasised presence of flatten_cv and others.
-2025-07-05: Added TODOs to port notebook metrics helpers (eval_at, eval_metrics, show_metrics, folds_df) into a new metrics module. Reason: these functions come from ai_arisha.py and would aid reproducibility.
-2025-07-06: Implemented random_split and time_split in src.split plus set_seeds in new utils module. Added tests, README note and ticked TODO. Decisions: handled tiny datasets in calculate_vif to keep tests stable under Python 3.12.
-2025-07-05: Implemented diagnostics_stats module with chi-square helpers and tests. Reason: port missing statistical diagnostics from TODO. Decisions: keep MC_N at 5000 as in notebook and add unit tests.
-2025-06-10: Ported eval_metrics, eval_at, show_metrics and folds_df into new metrics module with tests. Updated selection.vif_prune to handle infinite VIFs and stop pruning when two columns remain. Reason: implement TODO item. Decisions: treat inf VIF as large constant but stop dropping for last two cols.
-2025-07-06: Fixed vif_prune to skip VIF calculation when fewer than two columns remain and stop on infinite VIF with two columns. Reason: avoid singular matrix errors.
-2025-07-07: Removed unused pandas import from tests/test_metrics.py and tweaked calculate_vif small-sample handling so flake8 passes. Reason: tidy metrics tests and fix CI.
-2025-07-07: Rewrote vif_prune to remove duplicate logic, recalc VIFs each loop and return NaNs when <2 cols. Reason: simplify function and avoid dropped columns when two remain.
-2025-07-08: Added `_scaled_matrix`, `_check_mu_sigma` and `validate_prep` in preprocessing with unit tests. Reason: port scaling validation helpers from the notebook. Decisions: functions now accept DataFrames to avoid globals and raise ValueError on invalid scaling.
-2025-07-08: Implemented `is_binary_numeric` helper and added unit tests. Reason: port binary-check logic from notebook. Decisions: simple dtype check using `series.dtype.kind`.
-2025-07-07: Removed unused pandas import from tests/test_metrics.py and tweaked calculate_vif small-sample handling so flake8 passes. Reason: tidy metrics tests and fix CI.
-2025-06-10: Simplified vif_prune to drop one column at a time and removed stray docstring. Reason: tidy API and meet flake8 guidelines. Decisions: recalc VIFs after each drop to keep function short.
-2025-07-08: Added note in AGENTS.md to cross-check FUNCTIONS.md and record skipped notebook functions in NOTES.md. Reason: keep track of ported utilities.
-2025-07-07: Added sha256, shasum, save_folds and run_grid utilities with tests. Reason: unify artifact helpers from ai_arisha notebook. Decisions: new run_grid saves CV results.
-2025-06-10: Added cv_utils module with build_outer_iter and nested_cv plus tests covering bootstrap path. Reason: port CV bootstrap logic per TODO.
-2025-07-08: Added pipeline_helpers with lr_steps, tree_steps and run_gs. logreg and cart grid_search now call these helpers. Tests cover helper behaviour.
-2025-07-08: Found unported helpers _zeros, _dedup and _is_binary_numeric in ai_arisha.py. Added TODO section to track porting them into src/utils.py with tests.
-
+2025-06-09: added reporting module with helpers to assemble report and tests
+for flatten*cv and flatten_metrics.
+2025-07-02: Added evaluation_utils with plot_or_load and alias wrappers.
+Reason: implement new helper API. Decisions: keep wrappers thin for simplicity.
+2025-07-03: added tests for split.stratified_split verifying split lengths,
+stratification and index reset. Reason: cover TODO bullet.
+2025-07-03: Added safe_transform input validation tests for type errors and
+extra-column warnings as per TODO. Reason: improve preprocessing robustness.
+2025-07-03: Added CLI sampler integration test verifying mlcls-train works with
+SMOTE and prints ROC-AUC. Reason: extend CLI coverage for sampler option.
+2025-06-09: expanded FeatureEngineer tests for column normalisation, asset
+totals and risk flags. Reason: improve coverage per TODO. Decisions: use
+pytest.warns for missing asset warnings.
+2025-07-03: Added calibration tests for isotonic option and invalid method
+validation. Reason: strengthen coverage. Decisions: check
+`calibrated_classifiers*`attribute and expect ValueError for bad method.
+2025-07-03: Added make test target for simplified testing via pytest. Updated
+docs and guidelines.
+2025-07-04: Marked TODO item for Makefile test target as done and fixed
+Makefile tabs. 'make test' now invokes pytest correctly.
+2025-07-04: Marked TODO bullet for Makefile test target as completed. Reason:
+target already in Makefile.
+2025-07-05: Implemented`vif_prune`for iterative VIF pruning with tests and
+recorded TODO entry. Reason: port missing helper from ai_arisha.py.
+2025-07-05: Added TODO bullet listing missing statistical diagnostics from
+FUNCTIONS.md. Reason: document unported helpers for future diagnostics_stats
+module.
+2025-07-05: Added TODO bullet for missing random_split, time_split and
+set_seeds helper. Reason: these functions remain absent from src compared with
+the original notebook.
+2025-06-10: Clarified NOTES about reporting utilities in src/reporting.py when
+summarising ported functions. Reason: correct earlier statement. Decisions:
+emphasised presence of flatten_cv and others.
+2025-07-05: Added TODOs to port notebook metrics helpers (eval_at,
+eval_metrics, show_metrics, folds_df) into a new metrics module. Reason: these
+functions come from ai_arisha.py and would aid reproducibility.
+2025-07-06: Implemented random_split and time_split in src.split plus set_seeds
+in new utils module. Added tests, README note and ticked TODO. Decisions:
+handled tiny datasets in calculate_vif to keep tests stable under Python 3.12.
+2025-07-05: Implemented diagnostics_stats module with chi-square helpers and
+tests. Reason: port missing statistical diagnostics from TODO. Decisions: keep
+MC_N at 5000 as in notebook and add unit tests.
+2025-06-10: Ported eval_metrics, eval_at, show_metrics and folds_df into new
+metrics module with tests. Updated selection.vif_prune to handle infinite VIFs
+and stop pruning when two columns remain. Reason: implement TODO item.
+Decisions: treat inf VIF as large constant but stop dropping for last two cols.
+2025-07-06: Fixed vif_prune to skip VIF calculation when fewer than two columns
+remain and stop on infinite VIF with two columns. Reason: avoid singular matrix
+errors.
+2025-07-07: Removed unused pandas import from tests/test_metrics.py and tweaked
+calculate_vif small-sample handling so flake8 passes. Reason: tidy metrics
+tests and fix CI.
+2025-07-07: Rewrote vif_prune to remove duplicate logic, recalc VIFs each loop
+and return NaNs when <2 cols. Reason: simplify function and avoid dropped
+columns when two remain.
+2025-07-08: Added`\_scaled_matrix`, `\_check_mu_sigma`and`validate_prep`in
+preprocessing with unit tests. Reason: port scaling validation helpers from the
+notebook. Decisions: functions now accept DataFrames to avoid globals and raise
+ValueError on invalid scaling.
+2025-07-08: Implemented`is_binary_numeric`helper and added unit tests. Reason:
+port binary-check logic from notebook. Decisions: simple dtype check
+using`series.dtype.kind`.
+2025-07-07: Removed unused pandas import from tests/test_metrics.py and tweaked
+calculate_vif small-sample handling so flake8 passes. Reason: tidy metrics
+tests and fix CI.
+2025-06-10: Simplified vif_prune to drop one column at a time and removed stray
+docstring. Reason: tidy API and meet flake8 guidelines. Decisions: recalc VIFs
+after each drop to keep function short.
+2025-07-08: Added note in AGENTS.md to cross-check FUNCTIONS.md and record
+skipped notebook functions in NOTES.md. Reason: keep track of ported utilities.
+2025-07-07: Added sha256, shasum, save_folds and run_grid utilities with tests.
+Reason: unify artifact helpers from ai_arisha notebook. Decisions: new run_grid
+saves CV results.
+2025-06-10: Added cv_utils module with build_outer_iter and nested_cv plus
+tests covering bootstrap path. Reason: port CV bootstrap logic per TODO.
+2025-07-08: Added pipeline_helpers with lr_steps, tree_steps and run_gs. logreg
+and cart grid_search now call these helpers. Tests cover helper behaviour.
+2025-07-08: Found unported helpers \_zeros, \_dedup and \_is_binary_numeric in
+ai_arisha.py. Added TODO section to track porting them into src/utils.py with
+tests.
+2025-07-08: Cleaned markdown docs, wrapped lines to 80 chars and fixed headings to satisfy markdownlint.

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ pyproject.toml           ← project build metadata
 requirements.txt         ← pip fallback
 LICENSE                  ← MIT
 README.md                ← you are here
-```
+```text
 
 ---
 
@@ -172,7 +172,7 @@ Values reproduced from the accompanying statistical report.&#x20;
 
 ## How to cite
 
-```
+```bibtex
 @misc{Starostin2025LoanApproval,
   author = {Ivan Starostin},
   title  = {ML\_classification: Loan-approval prediction pipelines},

--- a/TODO.md
+++ b/TODO.md
@@ -1,125 +1,155 @@
 # TODO: Modularise the Colab notebook
 
-All migration tasks are complete as of commit `8af97fc`. This checklist started from commit `dbd5184` when only the legacy `ai_arisha.py` and a few docs were present. The project now has modular code under `src/`, a suite of tests and CI workflow.
+All migration tasks are complete as of commit `8af97fc`. This checklist started
+from commit `dbd5184` when only the legacy `ai_arisha.py` and a few docs were
+present. The project now has modular code under `src/`, a suite of tests and CI
+workflow.
 
 ## 1. Basic project skeleton
-- [x] create directories: `.github/workflows/`, `src/models/`, `scripts/`, `tests/`, and `notebooks/`
-- [x] add minimal files listed in `AGENTS.md` and `README.md`: `environment.yml`, `requirements.txt`, `Dockerfile`, `Makefile`, `LICENSE`, `.gitignore`
 
-- [x] implement `scripts/download_data.py` to fetch the Kaggle dataset using `KAGGLE_USERNAME` and `KAGGLE_KEY`
+- [x] create directories: `.github/workflows/`, `src/models/`, `scripts/`,
+`tests/`, and `notebooks/`
+- [x] add minimal files listed in `AGENTS.md` and `README.md`:
+`environment.yml`, `requirements.txt`, `Dockerfile`, `Makefile`, `LICENSE`,
+`.gitignore`
+
+- [x] implement `scripts/download_data.py` to fetch the Kaggle dataset using
+`KAGGLE_USERNAME` and `KAGGLE_KEY`
 - [x] write `src/dataprep.py` to load the raw CSV and perform basic cleaning
 
 ## 3. Feature engineering
-- [x] move the lengthy feature engineering block from `ai_arisha.py` into `src/features.py`
-- [x] split out diagnostic plots and chi-square analysis into `src/diagnostics.py`
-- [x] provide preprocessing helpers under `src/preprocessing.py` and feature selection logic under `src/selection.py`
+
+- [x] move the lengthy feature engineering block from `ai_arisha.py` into
+`src/features.py`
+- [x] split out diagnostic plots and chi-square analysis into
+`src/diagnostics.py`
+- [x] provide preprocessing helpers under `src/preprocessing.py` and feature
+selection logic under `src/selection.py`
 
 ## 4. Modelling pipelines
-- [x] add `src/models/logreg.py` and `src/models/cart.py` for logistic regression and decision-tree pipelines respectively
-- [x] create `src/split.py` with stratified train/validation/test split utilities
-- [x] expose a simple command line entry point (e.g. `make train` or `python -m src.models.logreg`)
+
+- [x] add `src/models/logreg.py` and `src/models/cart.py` for logistic
+regression and decision-tree pipelines respectively
+- [x] create `src/split.py` with stratified train/validation/test split
+utilities
+- [x] expose a simple command line entry point (e.g. `make train` or `python -m
+src.models.logreg`)
 
 ## 5. Tests and CI
+
 - [x] add `tests/test_smoke.py` importing each module
 - [x] set up GitHub Actions workflow `ci.yml` running flake8/black and `pytest`
 - [x] add unit tests for `dataprep`, `features`, and `models` modules
 - [x] add unit tests for `split.stratified_split`
 
 ## 6. Documentation updates
+
 - [x] update `README.md` with new instructions once modules are in place
 - [x] remove note about missing model pipelines once they are added
-    (obsolete since README now describes both pipelines)
+      (obsolete since README now describes both pipelines)
 - [x] add brief usage notes to `notebooks/README.md`
 
 ## 7. Legacy script
+
 - keep `ai_arisha.py` read-only for reference until the migration is finished
 
 ## 8. Evaluation & fairness
+
 - [x] implement evaluation CLI and fairness metrics
 
+## Missing elements from the modularised project
 
-##Missing elements from the modularised project
-
-Inspection of ai_arisha.py reveals several features that were not ported to the src/ modules:
-
+Inspection of ai_arisha.py reveals several features that were not ported to the
+src/ modules:
 
 Extensive hyper‑parameter grids
 
-ai_arisha.py defines larger parameter grids for both logistic regression and decision tree models (e.g. varying C, penalty, class_weight, tree depth, leaf size). The modular code has minimal grids of two values for each model.
+ai_arisha.py defines larger parameter grids for both logistic regression and
+decision tree models (e.g. varying C, penalty, class_weight, tree depth, leaf
+size). The modular code has minimal grids of two values for each model.
 Grid-search flag now calls these grids from the CLI.
-ai_arisha.py defines larger parameter grids for both logistic regression and decision tree models (e.g. varying C, penalty, class_weight, tree depth, leaf size). The logistic grid is now exposed via ``grid_train_from_df`` but the tree model still uses a minimal grid.
-
+ai_arisha.py defines larger parameter grids for both logistic regression and
+decision tree models (e.g. varying C, penalty, class_weight, tree depth, leaf
+size). The logistic grid is now exposed via `grid_train_from_df` but the tree
+model still uses a minimal grid.
 
 Repeated cross‑validation and bootstrap logic
-The original script uses RepeatedStratifiedKFold and falls back to bootstrapping when the minority class is small, recording confidence intervals over folds. The modular code runs a single 3×3 nested CV without bootstrapping.
+The original script uses RepeatedStratifiedKFold and falls back to
+bootstrapping when the minority class is small, recording confidence intervals
+over folds. The modular code runs a single 3×3 nested CV without bootstrapping.
 
-Oversampling options, probability calibration, feature importance export, extended metrics and manifest writing were implemented in commit `0c16cae`.
+Oversampling options, probability calibration, feature importance export,
+extended metrics and manifest writing were implemented in commit `0c16cae`.
 
-- [x] Ported statistical helpers `_need_exact`, `_cramers_v`, `_cochran_armitage`,
-  `_safe_chi2`, and `_fmt_p`/`_annotate` into new
-  `src/diagnostics_stats.py` with unit tests.
+- [x] Ported statistical helpers `_need_exact`, `_cramers_v`,
+`_cochran_armitage`,
+      `_safe_chi2`, and `_fmt_p`/`_annotate` into new
+      `src/diagnostics_stats.py` with unit tests.
 
 ## 9. Usability improvements
-- [x] download_data prints guidance if src package cannot be imported.
- - [x] Clarify that `make` is needed for training commands and mention console scripts for Windows.
 
+- [x] download_data prints guidance if src package cannot be imported.
+- [x] Clarify that `make` is needed for training commands and mention console
+scripts for Windows.
 
 ## 10. Modelling improvements
-- [x] Add --grid-search option for repeated cross-validation and extended parameter grids.
+
+- [x] Add --grid-search option for repeated cross-validation and extended
+parameter grids.
 
 - [x] port grid search helper for decision tree
 
 - [x] save best estimator when performing cart grid search
 
-- [x] Verify that each function from ai_arisha.py is represented or intentionally omitted in the src modules (see FUNCTIONS.md).
+- [x] Verify that each function from ai_arisha.py is represented or
+intentionally omitted in the src modules (see FUNCTIONS.md).
 
 - [x] port reporting helpers for final artifact collection
 
 - [x] add evaluation_utils helpers for plotting and fairness aliases
 - [x] extend safe_transform tests for type error and warning handling
 
-
 - [x] add tests for calibrate_model isotonic option and invalid method handling
 
 - [x] add CLI test for sampler option
 
-- [x] extend FeatureEngineer unit tests for column normalisation, asset ratios and risk flag
-
+- [x] extend FeatureEngineer unit tests for column normalisation, asset ratios
+and risk flag
 
 - [x] add Makefile test target to run pytest
 - [x] port `_vif_prune` as `vif_prune` in `src/selection.py` with unit tests
 - [x] VIF pruning handles singular matrices
 
-
-
 ## 11. Metrics helpers
 
-- [x] Port notebook metrics helpers `eval_metrics`, `eval_at`, `show_metrics` and `folds_df` or confirm omission.
+- [x] Port notebook metrics helpers `eval_metrics`, `eval_at`, `show_metrics`
+and `folds_df` or confirm omission.
 - [x] Create `src/metrics.py` with unit tests for these functions.
-- [x] implement random_split and time_split in src/split.py; add set_seeds helper in new src/utils.py
+- [x] implement random_split and time_split in src/split.py; add set_seeds
+helper in new src/utils.py
 - [x] Simplify vif_prune to drop one column per iteration and recalc VIFs
 - [x] add `is_binary_numeric` helper in `src/utils.py` with unit tests
 
-
-
 - [x] Simplify vif_prune to drop one column per iteration and recalc VIFs
 
-- [x] Port sha256, shasum, save_folds and run_grid helpers into src.manifest with unit tests.
+- [x] Port sha256, shasum, save_folds and run_grid helpers into src.manifest
+with unit tests.
 
-
-- [x] Ported build_outer_iter and nested_cv with bootstrap fallback into new src/cv_utils.py with tests.
-
+- [x] Ported build_outer_iter and nested_cv with bootstrap fallback into new
+src/cv_utils.py with tests.
 
 ## 12. Preprocessing validation
-- [ ] Integrate `validate_prep` into training scripts to fail fast on bad scaling.
+
+- [ ] Integrate `validate_prep` into training scripts to fail fast on bad
+scaling.
 
 - [x] centralise grid-search helpers as pipeline_helpers
 
 ## 12. Utility helpers
 
-The original notebook defines small helper functions `_zeros`, `_dedup` and `_is_binary_numeric`. These create zero-filled series, merge lists without duplicates and detect 0/1 numeric columns. They are not yet present in the modular code.
+The original notebook defines small helper functions `_zeros`, `_dedup` and
+`_is_binary_numeric`. These create zero-filled series, merge lists without
+duplicates and detect 0/1 numeric columns. They are not yet present in the
+modular code.
+
 - [ ] Port these helpers into `src/utils.py` with accompanying unit tests.
-
-
-
-


### PR DESCRIPTION
## Summary
- rewrap root Markdown docs to 80 chars
- fix duplicate h1 headings in AGENTS.md
- specify fenced code languages in README
- record cleanup

## Testing
- `markdownlint AGENTS.md NOTES.md README.md TODO.md FUNCTIONS.md`

------
https://chatgpt.com/codex/tasks/task_e_68483769f44c8325af1ffea78b739e13