### PR TITLE
Fix TODO formatting

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -140,3 +140,4 @@ corresponding TODO items.
 2025-07-08: Added pipeline_helpers with lr_steps, tree_steps and run_gs. logreg and cart grid_search now call these helpers. Tests cover helper behaviour.
 2025-07-08: Found unported helpers _zeros, _dedup and _is_binary_numeric in ai_arisha.py. Added TODO section to track porting them into src/utils.py with tests.
 
+2025-07-09: Cleaned TODO checklist by removing duplicate bullets and inserting blank lines for markdownlint. Reason: keep tasks unique and lint clean.

--- a/TODO.md
+++ b/TODO.md
@@ -3,6 +3,7 @@
 All migration tasks are complete as of commit `8af97fc`. This checklist started from commit `dbd5184` when only the legacy `ai_arisha.py` and a few docs were present. The project now has modular code under `src/`, a suite of tests and CI workflow.
 
 ## 1. Basic project skeleton
+
 - [x] create directories: `.github/workflows/`, `src/models/`, `scripts/`, `tests/`, and `notebooks/`
 - [x] add minimal files listed in `AGENTS.md` and `README.md`: `environment.yml`, `requirements.txt`, `Dockerfile`, `Makefile`, `LICENSE`, `.gitignore`
 
@@ -10,45 +11,48 @@ All migration tasks are complete as of commit `8af97fc`. This checklist started 
 - [x] write `src/dataprep.py` to load the raw CSV and perform basic cleaning
 
 ## 3. Feature engineering
+
 - [x] move the lengthy feature engineering block from `ai_arisha.py` into `src/features.py`
 - [x] split out diagnostic plots and chi-square analysis into `src/diagnostics.py`
 - [x] provide preprocessing helpers under `src/preprocessing.py` and feature selection logic under `src/selection.py`
 
 ## 4. Modelling pipelines
+
 - [x] add `src/models/logreg.py` and `src/models/cart.py` for logistic regression and decision-tree pipelines respectively
 - [x] create `src/split.py` with stratified train/validation/test split utilities
 - [x] expose a simple command line entry point (e.g. `make train` or `python -m src.models.logreg`)
 
 ## 5. Tests and CI
+
 - [x] add `tests/test_smoke.py` importing each module
 - [x] set up GitHub Actions workflow `ci.yml` running flake8/black and `pytest`
 - [x] add unit tests for `dataprep`, `features`, and `models` modules
 - [x] add unit tests for `split.stratified_split`
 
 ## 6. Documentation updates
+
 - [x] update `README.md` with new instructions once modules are in place
 - [x] remove note about missing model pipelines once they are added
     (obsolete since README now describes both pipelines)
 - [x] add brief usage notes to `notebooks/README.md`
 
 ## 7. Legacy script
+
 - keep `ai_arisha.py` read-only for reference until the migration is finished
 
 ## 8. Evaluation & fairness
+
 - [x] implement evaluation CLI and fairness metrics
 
-
-##Missing elements from the modularised project
+## Missing elements from the modularised project
 
 Inspection of ai_arisha.py reveals several features that were not ported to the src/ modules:
-
 
 Extensive hyper‑parameter grids
 
 ai_arisha.py defines larger parameter grids for both logistic regression and decision tree models (e.g. varying C, penalty, class_weight, tree depth, leaf size). The modular code has minimal grids of two values for each model.
 Grid-search flag now calls these grids from the CLI.
 ai_arisha.py defines larger parameter grids for both logistic regression and decision tree models (e.g. varying C, penalty, class_weight, tree depth, leaf size). The logistic grid is now exposed via ``grid_train_from_df`` but the tree model still uses a minimal grid.
-
 
 Repeated cross‑validation and bootstrap logic
 The original script uses RepeatedStratifiedKFold and falls back to bootstrapping when the minority class is small, recording confidence intervals over folds. The modular code runs a single 3×3 nested CV without bootstrapping.
@@ -60,11 +64,12 @@ Oversampling options, probability calibration, feature importance export, extend
   `src/diagnostics_stats.py` with unit tests.
 
 ## 9. Usability improvements
-- [x] download_data prints guidance if src package cannot be imported.
- - [x] Clarify that `make` is needed for training commands and mention console scripts for Windows.
 
+- [x] download_data prints guidance if src package cannot be imported.
+- [x] Clarify that `make` is needed for training commands and mention console scripts for Windows.
 
 ## 10. Modelling improvements
+
 - [x] Add --grid-search option for repeated cross-validation and extended parameter grids.
 
 - [x] port grid search helper for decision tree
@@ -78,19 +83,15 @@ Oversampling options, probability calibration, feature importance export, extend
 - [x] add evaluation_utils helpers for plotting and fairness aliases
 - [x] extend safe_transform tests for type error and warning handling
 
-
 - [x] add tests for calibrate_model isotonic option and invalid method handling
 
 - [x] add CLI test for sampler option
 
 - [x] extend FeatureEngineer unit tests for column normalisation, asset ratios and risk flag
 
-
 - [x] add Makefile test target to run pytest
 - [x] port `_vif_prune` as `vif_prune` in `src/selection.py` with unit tests
 - [x] VIF pruning handles singular matrices
-
-
 
 ## 11. Metrics helpers
 
@@ -100,17 +101,12 @@ Oversampling options, probability calibration, feature importance export, extend
 - [x] Simplify vif_prune to drop one column per iteration and recalc VIFs
 - [x] add `is_binary_numeric` helper in `src/utils.py` with unit tests
 
-
-
-- [x] Simplify vif_prune to drop one column per iteration and recalc VIFs
-
 - [x] Port sha256, shasum, save_folds and run_grid helpers into src.manifest with unit tests.
-
 
 - [x] Ported build_outer_iter and nested_cv with bootstrap fallback into new src/cv_utils.py with tests.
 
-
 ## 12. Preprocessing validation
+
 - [ ] Integrate `validate_prep` into training scripts to fail fast on bad scaling.
 
 - [x] centralise grid-search helpers as pipeline_helpers
@@ -118,8 +114,5 @@ Oversampling options, probability calibration, feature importance export, extend
 ## 12. Utility helpers
 
 The original notebook defines small helper functions `_zeros`, `_dedup` and `_is_binary_numeric`. These create zero-filled series, merge lists without duplicates and detect 0/1 numeric columns. They are not yet present in the modular code.
+
 - [ ] Port these helpers into `src/utils.py` with accompanying unit tests.
-
-
-
-


### PR DESCRIPTION
## Summary
- clean duplicate tasks in TODO
- insert blank lines after section headings per markdownlint
- log the cleanup in NOTES

## Testing
- `markdownlint NOTES.md TODO.md`

------
https://chatgpt.com/codex/tasks/task_e_684837791b248325b26abb7eef49d718