### PR TITLE
Fix README formatting

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -148,3 +148,4 @@ along with `flatten_cv` and `flatten_metrics` live in `src/reporting.py`.
 All other utilities such as `_zeros` or `_vif_prune` remain unported.
 Marked the TODO item as complete to record this gap.
 
+2025-07-02: Fixed README code block closure by replacing the stray "```text" line with a closing code fence.

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ pyproject.toml           ← project build metadata
 requirements.txt         ← pip fallback
 LICENSE                  ← MIT
 README.md                ← you are here
-```text
+```
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -154,3 +154,4 @@ duplicates and detect 0/1 numeric columns. They are not yet present in the
 modular code.
 
 - [ ] Port these helpers into `src/utils.py` with accompanying unit tests.
+- [x] Fix README stray code block marker leaving rest in code.


### PR DESCRIPTION
## Summary
- close open code block in README
- document the change in NOTES and TODO

## Testing
- `npx -y markdownlint-cli@0.39.0 '**/*.md' --ignore node_modules` *(fails: line length, no bare URLs)*
- `find . -name '*.md' -not -path './node_modules/*' -print0 | xargs -0 -I {} npx -y markdown-link-check -q '{}'` *(fails: 4 dead links in README)*

------
https://chatgpt.com/codex/tasks/task_e_68483c84390c8325bf5bd56baf54bbb4