### PR TITLE
Fix markdownlint warnings across docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ ML_classification/
 ├─ scripts/
 │ └─ download_data.py # pulls dataset via Kaggle API
 ├─ src/
-│ ├─ __init__.py
+│ ├─ `__init__.py`
 │ ├─ calibration.py # probability calibration utilities
 │ ├─ cv_utils.py # cross-validation wrappers
 │ ├─ dataprep.py # load / clean raw data
@@ -65,7 +65,7 @@ ML_classification/
 │ ├─ train.py # orchestrates pipelines
 │ ├─ utils.py # small misc helpers
 │ └─ models/
-│    ├─ __init__.py
+│    ├─ `__init__.py`
 │    ├─ logreg.py # LR training / eval pipeline
 │    └─ cart.py # Decision-Tree pipeline
 ├─ tests/

--- a/NOTES.md
+++ b/NOTES.md
@@ -147,8 +147,14 @@ Besides
 along with `flatten_cv` and `flatten_metrics` live in `src/reporting.py`.
 All other utilities such as `_zeros` or `_vif_prune` remain unported.
 Marked the TODO item as complete to record this gap.
-2025-07-02: Updated README layout with new modules list and replaced docker compose reference with Dockerfile instructions.
-2025-07-02: Tidied TODO numbering and removed duplicate vif_prune item to keep the task list concise.
-2025-06-10: Updated AGENTS.md project structure with all modules and expanded test list; added docs-sync guideline.
+2025-07-02: Updated README layout with new modules list and replaced docker
+compose reference with Dockerfile instructions.
+2025-07-02: Tidied TODO numbering and removed duplicate vif_prune item to keep
+the task list concise.
+2025-06-10: Updated AGENTS.md project structure with all modules and expanded
+test list; added docs-sync guideline.
 
-2025-07-02: Fixed README code block closure by replacing the stray "```text" line with a closing code fence.
+2025-07-02: Fixed README code block closure by replacing the stray "```text"
+line with a closing code fence.
+
+2025-06-11: Fixed markdownlint issues across docs and updated README links.

--- a/README.md
+++ b/README.md
@@ -1,23 +1,32 @@
 # ML_classification
 
-> **A tidy, production-ready re-implementation of my Google Colab notebook for predicting loan approvals with logistic regression and decision-tree pipelines.**
+> **A tidy, production-ready re-implementation of my Google Colab notebook for
+> predicting loan approvals with logistic regression and decision-tree
+> pipelines.**
 
 [![Build & Test](https://github.com/IvanStarostin1984/ML_classification/actions/workflows/ci.yml/badge.svg)](../../actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 ![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue)
-![ROC-AUC 0.987 ± 0.008](https://img.shields.io/badge/Test ROC–AUC-0.987-±0.008-purple)
+![ROC-AUC 0.987 ± 0.008](https://img.shields.io/badge/Test%20ROC–AUC-0.987-±0.008-purple)
 
 ---
 
 ## What’s inside & why it matters
 
-* **End-to-end pipeline** – data download, cleaning, 80 + engineered features, rigorous feature selection, model tuning, and statistical evaluation.
-* **Statistical transparency** – every performance number is reported with 95 % bootstrap confidence intervals and a fairness check (four-fifths rule).
-* **Clean architecture** – each stage is its own Python module under `src/`, ready for unit tests and continuous integration.
-* **One-command reproducibility** – `make train` or run the Docker image from the provided `Dockerfile` to train the models and regenerate all artefacts.
+* **End-to-end pipeline** – data download, cleaning, 80 + engineered features,
+  rigorous feature selection, model tuning, and statistical evaluation.
+* **Statistical transparency** – every performance number is reported with
+  95 % bootstrap confidence intervals and a fairness check (four-fifths rule).
+* **Clean architecture** – each stage is its own Python module under `src/`,
+  ready for unit tests and continuous integration.
+* **One-command reproducibility** – `make train` or run the Docker image from
+  the provided `Dockerfile` to train the models and regenerate all artefacts.
 * **CI/CD ready** – GitHub Actions lint + pytest on every push.
 
-* **Modular utilities** – feature engineering and diagnostics are available as importable helpers.  Helpers like `split.random_split`, `split.time_split` and `utils.set_seeds` simplify experiments.
+* **Modular utilities** – feature engineering and diagnostics are available as
+  importable helpers. Helpers like `split.random_split`, `split.time_split` and
+  `utils.set_seeds` simplify experiments.
+
 ---
 
 ## Quick-start
@@ -79,8 +88,8 @@ command with `--grid-search` (or `-g`):
 ```bash
 mlcls-train --grid-search  # repeated CV with extended parameter grids
 ```
-This run takes longer but mirrors the notebook results.
 
+This run takes longer but mirrors the notebook results.
 
 ## Running tests
 
@@ -89,8 +98,8 @@ Execute the test-suite locally with:
 ```bash
 make test
 ```
-This sets `PYTHONPATH` so `pytest` can find the `src` package.
 
+This sets `PYTHONPATH` so `pytest` can find the `src` package.
 
 ## Command-line usage
 
@@ -130,11 +139,12 @@ This saves `logreg_calibration.png` and `cart_calibration.png` (plus
 ---
 
 ## Repository layout
+
 The project follows the target directory layout. Running `make train` now
 executes both the logistic regression and decision-tree pipelines located under
 `src/models`.
 
-```
+```text
 ai_arisha.py             ← legacy Colab script (read-only)
 AGENTS.md                ← contributor guidelines and architecture notes
 .github/workflows/ci.yml ← CI pipeline (Black, flake8, pytest)
@@ -195,4 +205,3 @@ Values reproduced from the accompanying statistical report.&#x20;
 ## Author
 
 **Ivan Starostin** – [LinkedIn](https://www.linkedin.com/in/ivanstarostin/)
-

--- a/TODO.md
+++ b/TODO.md
@@ -50,8 +50,9 @@ src.models.logreg`)
       (obsolete since README now describes both pipelines)
 - [x] add brief usage notes to `notebooks/README.md`
 - [x] refresh README layout with new modules and replace docker compose mention
-
 - [x] keep `AGENTS.md` project structure entries in sync with code and tests
+- [x] ensure markdown files pass `markdownlint`
+
 ## 7. Legacy script
 
 - keep `ai_arisha.py` read-only for reference until the migration is finished

--- a/data/README.md
+++ b/data/README.md
@@ -1,5 +1,7 @@
 # Dataset licence
 
-The dataset used for this project is the Kaggle "Loan Approval Prediction Dataset" (`architsharma01/loan-approval-prediction-dataset`).
-It is available only to users who agree to the Kaggle terms of use and dataset licence. Do not upload the raw dataset to this repository.
+The dataset used for this project is the Kaggle "Loan Approval Prediction
+Dataset" (`architsharma01/loan-approval-prediction-dataset`).
+It is available only to users who agree to the Kaggle terms of use and dataset
+licence. Do not upload the raw dataset to this repository.
 Use `scripts/download_data.py` with your Kaggle credentials to obtain the files locally.


### PR DESCRIPTION
## Summary
- wrap __init__ modules in AGENTS.md
- encode shield URL and reflow README text
- tidy data/README line breaks
- add documentation update note in NOTES and tick TODO

## Testing
- `npx -y markdownlint-cli@0.45.0 '**/*.md' --ignore node_modules`

------
https://chatgpt.com/codex/tasks/task_e_68498df44a18832582e5cb455a1b40cc