### PR TITLE
Fix NOTES formatting

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -153,15 +153,16 @@ compose reference with Dockerfile instructions.
 the task list concise.
 2025-06-10: Updated AGENTS.md project structure with all modules and expanded
 test list; added docs-sync guideline.
-
-
 2025-07-02: Fixed README code block closure by replacing the stray "```text```"
 line with a closing code fence.
 
-2025-07-03: Documented Markdown style guidelines in AGENTS.md and noted running `npx markdownlint-cli`
-before committing docs. Reason: to standardise doc formatting. Decisions: added bullet list under Coding Standards.
+2025-07-03: Documented Markdown style guidelines in AGENTS.md and noted running
+`npx markdownlint-cli` before committing docs. Reason: to standardise doc
+formatting. Decisions: added bullet list under Coding Standards.
 
-2025-07-02: Fixed README code block closure by replacing the stray "```text```" line with a closing code fence.
+2025-07-02: Fixed README code block closure by replacing the stray
+```text``` line with a closing code fence.
 
 2025-06-11: Fixed markdownlint issues across docs and updated README links.
-
+2025-07-16: Shortened long NOTES lines and removed stray blank lines so
+markdownlint passes.

--- a/TODO.md
+++ b/TODO.md
@@ -53,6 +53,7 @@ src.models.logreg`)
 - [x] keep `AGENTS.md` project structure entries in sync with code and tests
 - [x] document Markdown style guidelines in `AGENTS.md`
 - [x] ensure markdown files pass `markdownlint`
+- [x] shorten long NOTES lines to satisfy markdownlint
 
 ## 7. Legacy script
 


### PR DESCRIPTION
## Summary
- remove stray blank lines around lines 156–157 and 168 in NOTES
- split long NOTES lines to keep them under 80 characters
- record the cleanup as a dated entry
- tick TODO for shortening NOTES lines

## Testing
- `npx markdownlint-cli '**/*.md' --ignore node_modules`

------
https://chatgpt.com/codex/tasks/task_e_6849959245c48325b0bf4a33421f1222