### PR TITLE
Fix markdown blank lines

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -154,7 +154,6 @@ to keep the task list concise.
 2025-06-10: Updated AGENTS.md project structure with all modules and expanded
 test list; added docs-sync guideline.
 
-
 2025-07-02: Fixed README code block closure by replacing the stray "```text```"
 line with a closing code fence.
 
@@ -181,7 +180,6 @@ formatting. Decisions: added bullet list under Coding Standards.
 2025-07-02: Fixed README code block closure by replacing the stray
 ```text``` line with a closing code fence.
 
-
 2025-07-02: Fixed README code block closure by replacing the stray "```text```"
 line with a closing code fence.
 2025-06-11: Fixed markdownlint issues across docs and updated README links.
@@ -190,3 +188,5 @@ markdownlint passes.
 
 2025-07-03: Added TODO item for fixing long lines in NOTES.md to satisfy
 markdownlint. Reason: enforce doc style. Decision: bullet under docs updates.
+
+2025-07-20: Removed extra blank lines in NOTES.md to satisfy markdownlint.

--- a/TODO.md
+++ b/TODO.md
@@ -53,9 +53,8 @@ src.models.logreg`)
 - [x] keep `AGENTS.md` project structure entries in sync with code and tests
 - [x] document Markdown style guidelines in `AGENTS.md`
 - [x] ensure markdown files pass `markdownlint`
-- [ ] fix NOTES.md long lines to satisfy markdownlint
+- [x] fix NOTES.md long lines to satisfy markdownlint
 - [x] shorten long NOTES lines to satisfy markdownlint
-
 
 ## 7. Legacy script
 


### PR DESCRIPTION
## Summary
- remove stray blank lines in NOTES and TODO
- mark TODO item complete
- add entry about the cleanup in NOTES

## Testing
- `npm_config_yes=true npx markdownlint-cli '**/*.md' --ignore node_modules`

------
https://chatgpt.com/codex/tasks/task_e_684999e8ea708325a471b64c075172f8