### PR TITLE
Fix markdown link check command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,4 +61,4 @@ jobs:
       - name: Run markdownlint
         run: npx markdownlint-cli '**/*.md' --ignore node_modules
       - name: Check links
-        run: npx markdown-link-check -q '**/*.md'
+        run: find . -name '*.md' -not -path '*node_modules*' -print0 | xargs -0 -n1 npx markdown-link-check -q

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,8 +135,13 @@ ML_classification/
   same checks. Use `make test` to run the full pytest suite with the correct
 `PYTHONPATH`.
 - Black uses a line length of **88** as configured in `pyproject.toml`.
-- Docs-only commits run a fast job with `markdownlint` and
-   `markdown-link-check`.
+- Docs-only commits run a fast job with `markdownlint`.
+  Links are checked using:
+
+```bash
+find . -name '*.md' -not -path '*node_modules*' -print0 |
+  xargs -0 -n1 npx markdown-link-check -q
+```
 
 ## Contributing Workflow
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -196,3 +196,5 @@ markdownlint. Reason: enforce doc style. Decision: bullet under docs updates.
 2025-07-20: Removed extra blank lines in NOTES.md to satisfy markdownlint.
 
 2025-07-21: Removed extra blank lines for markdownlint compliance.
+2025-07-22: CI link check fixed to iterate over markdown files;
+  quoting glob failed before.

--- a/TODO.md
+++ b/TODO.md
@@ -42,6 +42,7 @@ src.models.logreg`)
 - [x] add unit tests for `dataprep`, `features`, and `models` modules
 - [x] add unit tests for `split.stratified_split`
 - [x] add docs-only CI job running markdownlint and markdown-link-check
+- [x] fix link check step to iterate over markdown files with find/xargs
 
 ## 6. Documentation updates
 


### PR DESCRIPTION
## Summary
- use `find` so CI checks links for each Markdown file
- document the new link-check command in AGENTS
- log the change in NOTES and TODO

## Testing
- `npx --yes markdownlint-cli '**/*.md' --ignore node_modules`
- `find . -name '*.md' -not -path '*node_modules*' -print0 | xargs -0 -n1 npx --yes markdown-link-check -q` *(fails: dead links in README)*
- `flake8`
- `black --check .`
- `pytest -q` *(fails: 23 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684adee36b408325bf74b5be18fb0f81