### PR TITLE
docs: clarify helper locations

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -145,8 +145,8 @@ Besides
 `safe_transform` and the fairness helpers `youden_threshold` and
 `four_fifths_ratio`, reporting utilities like `find_path` and `write_section`,
 along with `flatten_cv` and `flatten_metrics` live in `src/reporting.py`.
-All other utilities such as `_zeros` or `_vif_prune` remain unported.
-Marked the TODO item as complete to record this gap.
+All helpers are now ported. `_zeros` lives in `src/utils.py`.
+`_vif_prune` moved to `src/selection.py`. Marked the TODO item as complete.
 2025-07-02: Updated README layout with new modules list and replaced
 docker-compose reference with Dockerfile instructions.
 2025-07-02: Tidied TODO numbering and removed duplicate vif_prune item
@@ -205,3 +205,5 @@ markdownlint. Reason: enforce doc style. Decision: bullet under docs updates.
 2025-07-23: logistic and cart pipelines validate preprocessing before model
 training; tests mock `validate_prep` to ensure invocation. Reason: to fail fast
 on bad scaling and complete TODO item.
+2025-07-24: Clarified that `_zeros` and `_vif_prune` now reside in
+`src/utils.py` and `src/selection.py` and updated TODO text.

--- a/TODO.md
+++ b/TODO.md
@@ -155,8 +155,8 @@ scaling.
 
 - The original notebook defines small helper functions `_zeros`, `_dedup` and
   `_is_binary_numeric`. These create zero-filled series, merge lists without
-  duplicates and detect 0/1 numeric columns. They are not yet present in the
-  modular code.
+  duplicates and detect 0/1 numeric columns. They now live in `src/utils.py`
+  with unit tests.
 
 - [x] Port these helpers into `src/utils.py` with accompanying unit tests.
 - [x] Fix README stray code block marker leaving rest in code.


### PR DESCRIPTION
## Summary
- fix outdated note in NOTES about `_zeros` and `_vif_prune`
- update TODO helper section

## Testing
- `npx markdownlint-cli '**/*.md'`

------
https://chatgpt.com/codex/tasks/task_e_684ae9441c3c8325b05f882067228581