### PR TITLE
Update NOTES on metrics helper mapping

### DIFF
--- a/FUNCTIONS.md
+++ b/FUNCTIONS.md
@@ -76,5 +76,6 @@ registry.
   - `dump_cart_overfit(ff)` – compare CART CV vs test ROC AUC.
 
 Implemented later:
+
 - `prefix` – now `src.utils.prefix`.
 - `conf_matrix_summary` and `group_metrics` – moved to `src.report_helpers`.

--- a/NOTES.md
+++ b/NOTES.md
@@ -209,7 +209,7 @@ on bad scaling and complete TODO item.
 2025-07-24: Added prefix helper and new report_helpers module with
  conf_matrix_summary and group_metrics functions plus unit tests. Reason: port
  remaining notebook utilities for metrics summarisation. Decisions: expose via
- __all__ and document in FUNCTIONS.md.
+ `__all__` and document in FUNCTIONS.md.
 
 2025-07-24: Documented that `_sha` and `sha` were replaced by `sha256` and
 `shasum`. `_is_binary`, `_num_block` and `make_preprocessor` have no direct
@@ -218,3 +218,5 @@ equivalent. Reason: clarify function coverage and close TODO.
 2025-07-24: Clarified that `_zeros` and `_vif_prune` now reside in
 `src/utils.py` and `src/selection.py` and updated TODO text.
 
+2025-07-25: prefix, conf_matrix_summary and group_metrics implement the
+ notebook helpers `_prefix`, `_conf` and `_group_metrics`.

--- a/TODO.md
+++ b/TODO.md
@@ -164,7 +164,5 @@ scaling.
 ## 14. Reporting helpers
 
 - [x] Add prefix helper and metrics helpers in report_helpers.py with tests.
-
 - [x] Record in NOTES that `_sha`/`sha` map to `sha256`/`shasum` and
   `_is_binary`, `_num_block` and `make_preprocessor` remain unported.
-


### PR DESCRIPTION
## Summary
- note how metrics helpers map to notebook counterparts
- wrap `__all__` mention in backticks
- fix FUNCTIONS.md list spacing
- trim blank lines in TODO

## Testing
- `npx -y markdownlint-cli '**/*.md'`

------
https://chatgpt.com/codex/tasks/task_e_684b03555ee883259a9886ab3f69729e