### PR TITLE
Add prediction CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,7 @@ ML_classification/
 │ ├─ selection.py # VIF, RFE, tree selector
 │ ├─ split.py # stratified train/test logic
 │ ├─ train.py # orchestrates pipelines
+│ ├─ predict.py # prediction CLI
 │ ├─ utils.py # small misc helpers
 │ └─ models/
 │    ├─ `__init__.py`
@@ -75,6 +76,7 @@ ML_classification/
 │ ├─ test_cli_sampler.py # CLI data sampler functions
 │ ├─ test_cli_scripts.py # CLI wrappers
 │ ├─ test_cli_train_gridsearch.py # CLI grid search training
+│ ├─ test_predict.py # prediction CLI
 │ ├─ test_cv_utils.py # cross-validation helpers
 │ ├─ test_dataprep.py # data loading
 │ ├─ test_diagnostics.py # diagnostic utilities

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,6 +1,6 @@
 # Migration notes
 
-Current commit: `78a6950`.
+Current commit: `d8138d2`.
 2025-06-18: Evaluation and fairness modules are in place with passing tests and
 README instructions describing the workflow.
 
@@ -203,33 +203,23 @@ quoting glob failed before.
 2025-07-23: logistic and cart pipelines validate preprocessing before model
 training; tests mock `validate_prep` to ensure invocation. Reason: to fail fast
 on bad scaling and complete TODO item.
-
 2025-07-24: Added prefix helper and new report_helpers module with
- conf_matrix_summary and group_metrics functions plus unit tests.
- Reason: port remaining notebook utilities for metrics summarisation.
+conf_matrix_summary and group_metrics functions plus unit tests.
+Reason: port remaining notebook utilities for metrics summarisation.
 Decisions: expose via `__all__` and document in FUNCTIONS.md.
-
- conf_matrix_summary and group_metrics functions plus unit tests. Reason: port
- remaining notebook utilities for metrics summarisation. Decisions: expose via
- `__all__` and document in FUNCTIONS.md.
-
-
 2025-07-24: Documented that `_sha` and `sha` were replaced by `sha256` and
 `shasum`. `_is_binary`, `_num_block` and `make_preprocessor` have no direct
 equivalent. Reason: clarify function coverage and close TODO.
 2025-07-24: Clarified that `_zeros` and `_vif_prune` now reside in
 `src/utils.py` and `src/selection.py` and updated TODO text.
-
-
 2025-07-25: Implemented `_is_binary`, `_num_block` and `make_preprocessor`
  in `src/preprocessing.py` with unit tests. Reason: port missing helpers.
- Decisions: simplified make_preprocessor to use a single scaler for
- continuous columns.
-
+Decisions: simplified make_preprocessor to use a single scaler for
+continuous columns.
 2025-07-25: Updated NOTES commit hash to 78a6950 and cleaned trailing blank lines.
 Reason: keep history accurate.
 Decision: wrap `__all__` in backticks to satisfy markdownlint.
-
 2025-07-25: prefix, conf_matrix_summary and group_metrics implement the
- notebook helpers `_prefix`, `_conf` and `_group_metrics`.
-
+notebook helpers `_prefix`, `_conf` and `_group_metrics`.
+2025-06-13: Added `mlcls-predict` CLI to apply saved models. Tests cover the
+command and README lists it. Reason: enable simple batch prediction.

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ pip install -e .
 mlcls-train          # trains both models
 mlcls-train -g       # extensive grid search
 mlcls-eval           # evaluates the trained models
+mlcls-predict        # generates predictions from a saved model
 ```
 
 These commands require the Kaggle dataset, which is distributed under its

--- a/TODO.md
+++ b/TODO.md
@@ -169,3 +169,7 @@ scaling.
 - [x] Port `_is_binary`, `_num_block` and `make_preprocessor` into
   `src/preprocessing.py` with unit tests.
 
+## 15. Prediction CLI
+
+- [x] Add `src/predict.py` and console script `mlcls-predict` with tests.
+- [ ] Expand docs with examples on using the prediction command.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
 [project.scripts]
 mlcls-train = "src.train:main"
 mlcls-eval = "src.evaluate:main"
+mlcls-predict = "src.predict:main"
 
 [tool.setuptools]
 packages = ["src", "scripts"]

--- a/src/predict.py
+++ b/src/predict.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import joblib
+import pandas as pd
+
+
+def main(args: list[str] | None = None) -> None:
+    """CLI entry point applying a trained model to new data."""
+    parser = argparse.ArgumentParser(description="Generate predictions")
+    parser.add_argument(
+        "--model-path",
+        type=Path,
+        required=True,
+        help="joblib model path",
+    )
+    parser.add_argument(
+        "--data",
+        type=Path,
+        required=True,
+        help="CSV of features for prediction",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=Path("predictions.csv"),
+        help="output CSV path",
+    )
+    ns = parser.parse_args(args)
+
+    model = joblib.load(ns.model_path)
+    df = pd.read_csv(ns.data)
+
+    if hasattr(model, "predict_proba"):
+        preds = model.predict_proba(df)[:, 1]
+    else:
+        preds = model.predict(df)
+
+    out_df = pd.DataFrame({"prediction": preds})
+    ns.out.parent.mkdir(parents=True, exist_ok=True)
+    out_df.to_csv(ns.out, index=False)
+    print(f"Predictions written to {ns.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import os
+import sys
+import subprocess
+import sysconfig
+from pathlib import Path
+
+import pandas as pd
+from sklearn.datasets import make_classification
+from sklearn.linear_model import LogisticRegression
+import joblib
+
+
+def _toy_data() -> tuple[pd.DataFrame, pd.Series]:
+    X, y = make_classification(
+        n_samples=20,
+        n_features=3,
+        n_informative=3,
+        n_redundant=0,
+        random_state=0,
+    )
+    df = pd.DataFrame(X, columns=[f"f{i}" for i in range(X.shape[1])])
+    return df, pd.Series(y)
+
+
+def test_cli_predict(tmp_path) -> None:
+    df, y = _toy_data()
+    model = LogisticRegression(max_iter=1000).fit(df, y)
+    model_path = tmp_path / "model.joblib"
+    joblib.dump(model, model_path)
+
+    data_path = tmp_path / "data.csv"
+    df.to_csv(data_path, index=False)
+
+    root = Path(__file__).resolve().parents[1]
+    subprocess.run(
+        [sys.executable, "-m", "pip", "install", "-e", str(root)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    env = os.environ.copy()
+    scripts_dir = Path(sysconfig.get_path("scripts"))
+    env["PATH"] = str(scripts_dir) + os.pathsep + env.get("PATH", "")
+
+    res = subprocess.run(
+        [
+            "mlcls-predict",
+            "--model-path",
+            str(model_path),
+            "--data",
+            str(data_path),
+        ],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert "Predictions written" in res.stdout
+
+    out = tmp_path / "predictions.csv"
+    assert out.exists()
+    preds = pd.read_csv(out)
+    assert len(preds) == len(df)


### PR DESCRIPTION
## Summary
- add `src/predict.py` for generating predictions
- expose new `mlcls-predict` console command
- test the prediction CLI
- document the command in README
- log and plan work in NOTES.md and TODO.md
- list new files in AGENTS.md

## Testing
- `black --check .`
- `flake8`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684bdca3ba688325b23fb42109d5d817