### PR TITLE
Add loan demo notebook

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -244,3 +244,7 @@ Linked from README and docs index. Marked TODO items as done.
 2025-07-28: Added Sphinx to requirements and conda env.
 README now tells users to install it before building docs.
 AGENTS notes the dependency.
+
+2025-07-29: Created loan_demo.ipynb demoing data loading, feature
+engineering and model training via src package. Updated notebooks/README.md
+with link and run steps.

--- a/TODO.md
+++ b/TODO.md
@@ -176,3 +176,5 @@ scaling.
 
 - [x] Add `src/predict.py` and console script `mlcls-predict` with tests.
 - [x] Expand docs with examples on using the prediction command.
+
+- [ ] Add additional notebook examples demonstrating advanced use cases.

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -4,12 +4,19 @@
 This folder is for short Jupyter demos of the package. They are not required
 for training the models but can be handy for quick experiments.
 
+## Available notebooks
+
+- [loan_demo.ipynb](loan_demo.ipynb) – data loading, feature engineering
+  and training example.
+
+Run the commands below to open a notebook:
+
 ```bash
 # Ensure the Kaggle dataset is downloaded first
 python scripts/download_data.py
 
 # Then start Jupyter
-jupyter notebook
+jupyter notebook loan_demo.ipynb
 ```
 
 You can also open the notebooks directly in Google Colab via the GitHub link.

--- a/notebooks/loan_demo.ipynb
+++ b/notebooks/loan_demo.ipynb
@@ -1,0 +1,40 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Loan classification demo\n",
+    "This notebook demonstrates loading the dataset, engineering features, and training a model using the `src` package."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from src import dataprep, features\n",
+    "from src.models import logreg\n",
+    "\n",
+    "df = dataprep.load_raw('data/loan.csv')\n",
+    "fe = features.FeatureEngineer()\n",
+    "df_fe = fe.fit_transform(df)\n",
+    "model = logreg.fit(df_fe)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add simple `loan_demo.ipynb` showing dataset loading, feature engineering and training
- reference the demo notebook from `notebooks/README.md`
- log the addition in `NOTES.md` and add a TODO for further demos

## Testing
- `npx markdownlint-cli '**/*.md' --ignore node_modules`
- `find . -name '*.md' -not -path '*node_modules*' -print0 | xargs -0 -n1 npx markdown-link-check -q` (fails: 4 dead links)
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684bf11af98c8325b3dd93b97a777628