### PR TITLE
Fix README badges and link-check config

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -1,0 +1,5 @@
+{
+  "ignorePatterns": [
+    { "pattern": "linkedin.com" }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,7 @@ ML_classification/
 ├─ Dockerfile # reproducible container build
 ├─ Makefile # one-command workflow (`make train`)
 ├─ .gitignore # excludes data, artefacts, secrets
+├─ .markdown-link-check.json # patterns for link checker to ignore
 ├─ LICENSE # MIT License
 └─ README.md # badges, quick-start, results, contact
 
@@ -148,6 +149,9 @@ ML_classification/
 find . -name '*.md' -not -path '*node_modules*' -print0 |
   xargs -0 -n1 npx markdown-link-check -q
 ```
+
+The tool reads `.markdown-link-check.json` for patterns of external links to
+ignore. Links to social profiles like LinkedIn may be skipped there.
 
 ## Contributing Workflow
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -267,3 +267,4 @@ lines short. Reason: markdownlint flagged the long badge line.
 2025-07-31: Added advanced_demo.ipynb demonstrating grid-search training,
 fairness evaluation and calibration. Updated README files accordingly and
 checked off the notebook TODO item.
+2025-08-01: Updated README badges and added ignore file for LinkedIn links.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 > predicting loan approvals with logistic regression and decision-tree
 > pipelines.**
 
-[![Build & Test](https://github.com/IvanStarostin1984/ML_classification/actions/workflows/ci.yml/badge.svg)](../../actions)
+[![Build & Test](https://img.shields.io/github/actions/workflow/status/IvanStarostin1984/ML_classification/ci.yml?branch=main)](https://github.com/IvanStarostin1984/ML_classification/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 ![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue)
 [![ROC-AUC 0.987 ± 0.008][roc-badge]]
@@ -227,4 +227,4 @@ Values reproduced from the accompanying statistical report.&#x20;
 
 **Ivan Starostin** – [LinkedIn](https://www.linkedin.com/in/ivanstarostin/)
 
-[roc-badge]: https://img.shields.io/static/v1?label=Test%20ROC%20AUC&message=0.987%C2%B10.008&color=purple
+[roc-badge]: https://img.shields.io/static/v1?label=Test%20ROC-AUC&message=0.987%C2%B10.008&color=purple

--- a/TODO.md
+++ b/TODO.md
@@ -187,3 +187,5 @@ scaling.
 - [x] Update docs job to use upload-artifact@v4.
 
 - [x] Add additional notebook examples demonstrating advanced use cases.
+- [x] Update README badges and add `.markdown-link-check.json` to ignore
+      LinkedIn links.


### PR DESCRIPTION
## Summary
- fix Build & Test badge to point to GitHub actions and new image URL
- update ROC-AUC badge link
- ignore LinkedIn links for markdown link check
- document new config in `AGENTS.md`
- log changes in `NOTES.md` and `TODO.md`

## Testing
- `npx markdownlint-cli '**/*.md' --ignore node_modules`
- `find . -name '*.md' -not -path '*node_modules*' -print0 | xargs -0 -n1 npx markdown-link-check -q -c .markdown-link-check.json` *(fails: https://github.com/IvanStarostin1984/ML_classification/actions → 404)*

------
https://chatgpt.com/codex/tasks/task_e_684d3f6b2a108325afaf72ec6cef65b6