### PR TITLE
Add reporting CLI entry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ ML_classification/
 │ ├─ metrics.py # metric utilities from notebook
 │ ├─ pipeline_helpers.py # CLI and pipeline orchestrators
 │ ├─ preprocessing.py # ColumnTransformers
-│ ├─ reporting.py # reporting helpers
+│ ├─ reporting.py # reporting helpers, CLI `mlcls-report`
 │ ├─ report_helpers.py # confusion matrix and group metrics
 │ ├─ selection.py # VIF, RFE, tree selector
 │ ├─ split.py # stratified train/test logic

--- a/NOTES.md
+++ b/NOTES.md
@@ -268,3 +268,4 @@ lines short. Reason: markdownlint flagged the long badge line.
 fairness evaluation and calibration. Updated README files accordingly and
 checked off the notebook TODO item.
 2025-08-01: Updated README badges and added ignore file for LinkedIn links.
+2025-06-14: Added mlcls-report CLI with test and docs. CITATION stayed same.

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ mlcls-train          # trains both models
 mlcls-train -g       # extensive grid search
 mlcls-eval           # evaluates the trained models
 mlcls-predict        # generates predictions from a saved model
+mlcls-report        # collects report artifacts
 ```
 
 These commands require the Kaggle dataset, which is distributed under its

--- a/TODO.md
+++ b/TODO.md
@@ -189,3 +189,7 @@ scaling.
 - [x] Add additional notebook examples demonstrating advanced use cases.
 - [x] Update README badges and add `.markdown-link-check.json` to ignore
       LinkedIn links.
+
+## 17. Reporting CLI
+
+- [x] expose mlcls-report console script for collecting report artifacts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,8 @@ version = "0.1.0"
 description = "Loan-approval prediction pipelines"
 readme = "README.md"
 requires-python = ">=3.10"
+authors = [{name = "Ivan Starostin"}]
+license = {text = "MIT"}
 dependencies = [
     "pandas",
     "numpy",
@@ -25,6 +27,7 @@ dependencies = [
 mlcls-train = "src.train:main"
 mlcls-eval = "src.evaluate:main"
 mlcls-predict = "src.predict:main"
+mlcls-report = "src.reporting:main"
 
 [tool.setuptools]
 packages = ["src", "scripts"]

--- a/tests/test_cli_report.py
+++ b/tests/test_cli_report.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import os
+import sys
+import subprocess
+import sysconfig
+from pathlib import Path
+
+
+def test_cli_report(tmp_path) -> None:
+    root = Path(__file__).resolve().parents[1]
+    subprocess.run([
+        sys.executable,
+        '-m',
+        'pip',
+        'install',
+        '-e',
+        str(root),
+    ], check=True, capture_output=True, text=True)
+
+    env = os.environ.copy()
+    scripts_dir = Path(sysconfig.get_path('scripts'))
+    env['PATH'] = str(scripts_dir) + os.pathsep + env.get('PATH', '')
+
+    subprocess.run(
+        ['mlcls-report'],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    out = tmp_path / 'report_artifacts' / 'pipeline_tables.txt'
+    assert out.exists()


### PR DESCRIPTION
## Summary
- add `mlcls-report` console script in pyproject
- list mlcls-report usage in README
- mention CLI under project structure
- track new script in TODO and NOTES
- test mlcls-report in new `tests/test_cli_report.py`

## Testing
- `npx markdownlint-cli '**/*.md' --ignore node_modules`
- `black --check .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d460911688325b08bdacd63dd28fd