### PR TITLE
Add Binder configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ ML_classification/
 ├─ data/
 │ └─ README.md # Kaggle‐licence notice & instructions
 ├─ notebooks/
-│ └─ README.md # slim Colab/Binder demo stub
+│ └─ README.md # notebook guides and Binder badge
 ├─ scripts/
 │ └─ download_data.py # pulls dataset via Kaggle API
 ├─ src/
@@ -103,6 +103,9 @@ ML_classification/
 │ ├─ test_utils.py # miscellaneous utils
 ├─ environment.yml # Conda spec (Python ≥ 3.10)
 ├─ requirements.txt # pip fallback
+├─ binder/
+│  ├─ environment.yml # Binder spec referencing requirements
+│  └─ postBuild # installs the package in editable mode
 ├─ Dockerfile # reproducible container build
 ├─ Makefile # one-command workflow (`make train`)
 ├─ .gitignore # excludes data, artefacts, secrets
@@ -172,6 +175,9 @@ to track work.
 - Sphinx now builds an API reference from docstrings in
   `docs/api_reference.rst`.
 - Build distribution packages with `python -m build` to create a wheel.
+- Binder support lives in `binder/` with an `environment.yml` referencing the
+  project requirements and a `postBuild` script installing the package in
+  editable mode.
 
 Read `NOTES.md` and `TODO.md` to understand the current stage, past decisions,
 and open questions tied to the spec.

--- a/NOTES.md
+++ b/NOTES.md
@@ -299,3 +299,5 @@ ignore for actions URL. Reason: enforce MD012 and fix link check.
 
 2025-08-17: Documented mlcls-report usage in cli_usage.rst and explained the
 report_artifacts folder. Reason: show how to collect results for sharing.
+2025-08-18: Added Binder setup (environment.yml and postBuild) and badge link.
+Documented binder folder in README and AGENTS. Reason: enable online notebooks.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ See [data/README.md](data/README.md) for dataset licence notes.
 
 Interactive notebooks live under `notebooks/`. Open `loan_demo.ipynb` or
 `advanced_demo.ipynb` for a guided walkthrough.
+You can also launch them instantly on Binder via the badge in
+`notebooks/README.md`.
 
 Training produces feature-importance tables (`logreg_coefficients.csv`,
 `cart_importances.csv`) and bar-chart PNGs in `artefacts/`. All generated files
@@ -206,6 +208,8 @@ src/utils.py             ← general helpers
 tests/                   ← pytest suite
 data/README.md           ← dataset licence notes
 notebooks/README.md      ← Colab/Binder demo stub
+binder/environment.yml   ← Binder spec
+binder/postBuild         ← install step
 Dockerfile, Makefile     ← reproducible build & workflow helpers
 environment.yml          ← Conda spec (Python ≥ 3.10)
 pyproject.toml           ← project build metadata

--- a/TODO.md
+++ b/TODO.md
@@ -203,3 +203,9 @@ scaling.
 ## 18. Packaging
 
 - [x] add build-system entry and document wheel creation with `python -m build`
+
+## 19. Binder support
+
+- [x] add binder/environment.yml referencing requirements
+- [x] create postBuild script to install package in editable mode
+- [ ] update docs if binder instructions change

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,0 +1,8 @@
+name: ml-classification
+channels:
+  - conda-forge
+dependencies:
+  - python>=3.10
+  - pip
+  - pip:
+      - -r ../requirements.txt

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,2 @@
+#!/bin/bash
+pip install -e .

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -22,3 +22,6 @@ jupyter notebook loan_demo.ipynb  # or advanced_demo.ipynb
 ```
 
 You can also open the notebooks directly in Google Colab via the GitHub link.
+Alternatively launch them in Binder:
+
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/IvanStarostin1984/ML_classification/HEAD?labpath=notebooks%2Floan_demo.ipynb)


### PR DESCRIPTION
## Summary
- add Binder spec and install hook under `binder/`
- include Binder badge in notebook README
- mention Binder launch in main README and AGENTS
- log Binder setup in NOTES and TODO

## Testing
- `npx markdownlint-cli '**/*.md' --ignore node_modules`
- `flake8`
- `black --check .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684d60b7fc0883259b3b18a4d57e2666