### PR TITLE
Improve Binder docs

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -308,3 +308,7 @@ Reason: enforce consistent formatting automatically.
 
 2025-08-18: Added Binder setup (environment.yml and postBuild) and badge link.
 Documented binder folder in README and AGENTS. Reason: enable online notebooks.
+
+2025-08-26: Documented how to launch notebooks on Binder in notebooks README
+and linked the badge from docs/index.rst. Reason: clarify quick start and
+complete Binder docs TODO.

--- a/TODO.md
+++ b/TODO.md
@@ -210,4 +210,4 @@ scaling.
 
 - [x] add binder/environment.yml referencing requirements
 - [x] create postBuild script to install package in editable mode
-- [ ] update docs if binder instructions change
+- [x] update docs if binder instructions change

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,9 @@
 Welcome to ML_classification's documentation
 ============================================
 
-See :doc:`advanced_usage` for steps on fairness checks and calibration.
+See :doc:`advanced_usage` for steps on fairness checks and calibration. See the
+Binder badge in :file:`notebooks/README.md` for a quick start running the demo
+notebooks online.
 
 .. toctree::
    :maxdepth: 2

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -11,6 +11,10 @@ for training the models but can be handy for quick experiments.
 - [advanced_demo.ipynb](advanced_demo.ipynb) – grid search training,
   fairness evaluation and calibration.
 
+Click the Binder badge at the bottom of this page to run these demos in the
+cloud. Binder starts a temporary environment with all requirements so you can
+execute the steps without installing anything locally.
+
 Run the commands below to open a notebook:
 
 ```bash


### PR DESCRIPTION
## Summary
- explain Binder launch in notebooks README
- link to Binder badge from docs index
- log Binder doc update in NOTES and mark TODO as done

## Testing
- `npx -y markdownlint-cli '**/*.md' --ignore node_modules`
- `make docs`

------
https://chatgpt.com/codex/tasks/task_e_684d660364608325a70378658745dc7f