### PR TITLE
docs: mark isort hook complete

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -319,3 +319,6 @@ keep imports consistent.
 2025-08-26: Documented how to launch notebooks on Binder in notebooks README
 and linked the badge from docs/index.rst. Reason: clarify quick start and
 complete Binder docs TODO.
+
+2025-08-27: Cleaned up packaging roadmap. Checked off isort hook item
+because pre-commit already runs isort.

--- a/TODO.md
+++ b/TODO.md
@@ -204,8 +204,6 @@ scaling.
 
 - [x] add build-system entry and document wheel creation with `python -m build`
 - [x] publish the wheel to PyPI once the release workflow is battle-tested
-- [ ] add isort hook to pre-commit for import ordering
-- [ ] publish the wheel to PyPI once the release workflow is battle-tested
 - [x] add isort hook to pre-commit for import ordering
 
 ## 19. Binder support


### PR DESCRIPTION
## Summary
- remove duplicated PyPI publishing item and check off isort task in TODO
- log cleanup in NOTES

## Testing
- `npx --yes markdownlint-cli '**/*.md' --ignore node_modules` *(fails: npm needs internet access)*

------
https://chatgpt.com/codex/tasks/task_e_684d6b0cb5388325a00637df9ae61b31