### PR TITLE
Add random forest model and docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,8 @@ ML_classification/
 │ └─ models/
 │    ├─ `__init__.py`
 │    ├─ logreg.py # LR training / eval pipeline
-│    └─ cart.py # Decision-Tree pipeline
+│    ├─ cart.py # Decision-Tree pipeline
+│    └─ random_forest.py # Random-Forest pipeline
 ├─ tests/
 │ ├─ test_calibration.py # probability calibration
 │ ├─ test_cart_gridsearch.py # CART grid-search pipeline
@@ -94,6 +95,7 @@ ML_classification/
 │ ├─ test_metrics.py # metric utilities
 │ ├─ test_models.py # modelling pipelines
 │ ├─ test_oversampling.py # oversampling heuristics
+│ ├─ test_random_forest.py # random-forest pipeline
 │ ├─ test_pipeline_helpers.py # pipeline helpers
 │ ├─ test_preprocessing.py # preprocessing pipeline
 │ ├─ test_reporting.py # reporting utilities

--- a/NOTES.md
+++ b/NOTES.md
@@ -338,3 +338,7 @@ tests accordingly.
 2025-08-28: CI now runs pre-commit on changed files before flake8, black and
 pytest. Updated AGENTS and README. Fixed markdownlint hook pattern in
 .pre-commit-config.yaml. Reason: enforce hooks in pipeline.
+
+2025-08-29: Added random_forest model mirroring logreg/cart with CLI support,
+tests and documentation. Reason: extend modelling options. Decisions: use
+RandomForestClassifier with simple grid search and expose via train.py.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # ML_classification
 
 > **A tidy, production-ready re-implementation of my Google Colab notebook for
-> predicting loan approvals with logistic regression and decision-tree
-> pipelines.**
+> predicting loan approvals with logistic regression, decision-tree and
+> random-forest pipelines.**
 
 [![Build & Test](https://img.shields.io/github/actions/workflow/status/IvanStarostin1984/ML_classification/ci.yml?branch=main)](https://github.com/IvanStarostin1984/ML_classification/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
@@ -76,6 +76,7 @@ make eval             # evaluate trained models and check fairness
 # or individually
 make train-logreg
 make train-cart
+mlcls-train --model random_forest  # train only the RF model
 mlcls-train --sampler smote   # run with SMOTE oversampling
 ```
 
@@ -209,6 +210,7 @@ scripts/download_data.py ← Kaggle dataset pull helper
 src/                     ← Python package skeleton
 src/models/logreg.py     ← logistic regression pipeline
 src/models/cart.py       ← decision-tree pipeline
+src/models/random_forest.py ← random-forest pipeline
 src/features.py          ← FeatureEngineer class
 src/diagnostics.py       ← chi-square & correlation plots
 src/preprocessing.py     ← ColumnTransformer helpers

--- a/TODO.md
+++ b/TODO.md
@@ -135,6 +135,7 @@ and risk flag
 - [x] add Makefile test target to run pytest
 - [x] port `_vif_prune` as `vif_prune` in `src/selection.py` with unit tests
 - [x] VIF pruning handles singular matrices
+- [x] add random_forest model pipeline with CLI and tests
 
 ## 11. Metrics helpers
 

--- a/docs/cli_usage.rst
+++ b/docs/cli_usage.rst
@@ -8,6 +8,7 @@ Examples below assume the project is installed in editable mode::
 Train models and store artefacts under ``artefacts/``::
 
    mlcls-train --model logreg
+   mlcls-train --model random_forest
    mlcls-train -g  # grid search
 
 Evaluate metrics and write ``artefacts/summary_metrics.csv``::

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,0 +1,5 @@
+"""Model training pipelines."""
+
+from . import logreg, cart, random_forest
+
+__all__ = ["logreg", "cart", "random_forest"]

--- a/src/models/random_forest.py
+++ b/src/models/random_forest.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import joblib
+import pandas as pd
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.metrics import roc_auc_score
+from imblearn.base import SamplerMixin
+from imblearn.pipeline import Pipeline
+
+from ..dataprep import clean
+from ..features import FeatureEngineer
+from ..preprocessing import build_preprocessor, validate_prep
+from ..pipeline_helpers import tree_steps, run_gs
+from ..split import stratified_split
+
+DATA_PATH = Path("data/raw/loan_approval_dataset.csv")
+TARGET = "loan_status"
+
+
+def load_data(path: str | Path = DATA_PATH) -> pd.DataFrame:
+    """Return cleaned and engineered DataFrame loaded from ``path``."""
+    df = pd.read_csv(Path(path))
+    df = clean(df)
+    return FeatureEngineer().transform(df)
+
+
+def build_pipeline(
+    cat_cols: list[str], num_cols: list[str], sampler: SamplerMixin | None = None
+) -> Pipeline:
+    """Create preprocessing and random-forest pipeline."""
+    preproc = build_preprocessor(num_cols, cat_cols)
+    model = RandomForestClassifier(random_state=42)
+    steps = [("prep", preproc)]
+    if sampler is not None:
+        steps.append(("sampler", sampler))
+    steps.append(("model", model))
+    return Pipeline(steps)
+
+
+def train_from_df(
+    df: pd.DataFrame,
+    target: str = TARGET,
+    artefact_path: Path | None = None,
+    sampler: SamplerMixin | None = None,
+) -> float:
+    """Train model on ``df`` and return validation ROC-AUC."""
+    train_df, val_df, _ = stratified_split(df, target)
+    x_train = train_df.drop(columns=[target])
+    y_train = train_df[target]
+    x_val = val_df.drop(columns=[target])
+    y_val = val_df[target]
+    cat_cols = x_train.select_dtypes(include=["object", "category"]).columns.tolist()
+    num_cols = [c for c in x_train.columns if c not in cat_cols]
+    pipe = build_pipeline(cat_cols, num_cols, sampler)
+    pipe.named_steps["prep"].fit(x_train, y_train)
+    validate_prep(pipe.named_steps["prep"], x_train, "random_forest")
+    pipe.fit(x_train, y_train)
+    pred = pipe.predict_proba(x_val)[:, 1]
+    auc = roc_auc_score(y_val, pred)
+    if artefact_path:
+        artefact_path.parent.mkdir(parents=True, exist_ok=True)
+        joblib.dump(pipe, artefact_path)
+    return auc
+
+
+def grid_train_from_df(
+    df: pd.DataFrame,
+    target: str = TARGET,
+    artefact_path: Path | None = None,
+    sampler: SamplerMixin | None = None,
+):
+    """Return fitted GridSearchCV and optionally save best model."""
+    x, y = df.drop(columns=[target]), df[target]
+    cat_cols = x.select_dtypes(include=["object", "category"]).columns.tolist()
+    num_cols = [c for c in x.columns if c not in cat_cols]
+    preproc = build_preprocessor(num_cols, cat_cols)
+    preproc.fit(x, y)
+    validate_prep(preproc, x, "random_forest")
+    steps = tree_steps(preproc, sampler or "passthrough")
+    grid = {
+        "model__n_estimators": [50, 100],
+        "model__max_depth": [None, 10],
+        "model__min_samples_leaf": [1, 5],
+        "model__min_samples_split": [2, 10],
+        "model__class_weight": [None, "balanced"],
+    }
+    gs = run_gs(x, y, steps, RandomForestClassifier(random_state=42), grid)
+    if artefact_path:
+        artefact_path.parent.mkdir(parents=True, exist_ok=True)
+        joblib.dump(gs.best_estimator_, artefact_path)
+    return gs
+
+
+def main(
+    data_path: str | Path = DATA_PATH, sampler: SamplerMixin | None = None
+) -> None:
+    df = load_data(data_path)
+    auc = train_from_df(
+        df, artefact_path=Path("artefacts/random_forest.joblib"), sampler=sampler
+    )
+    print(f"Validation ROC-AUC: {auc:.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/train.py
+++ b/src/train.py
@@ -7,7 +7,7 @@ from imblearn.over_sampling import RandomOverSampler, SMOTE, SMOTEN, SMOTENC
 from imblearn.under_sampling import RandomUnderSampler
 from imblearn.combine import SMOTETomek
 
-from .models import logreg, cart
+from .models import logreg, cart, random_forest
 
 
 def main(args: list[str] | None = None) -> None:
@@ -17,8 +17,8 @@ def main(args: list[str] | None = None) -> None:
         "--model",
         "-m",
         action="append",
-        choices=["logreg", "cart"],
-        help="models to train; defaults to both",
+        choices=["logreg", "cart", "random_forest"],
+        help="models to train; defaults to all",
     )
     parser.add_argument(
         "--data-path",
@@ -46,7 +46,7 @@ def main(args: list[str] | None = None) -> None:
         help="use grid search to tune hyperparameters",
     )
     ns = parser.parse_args(args)
-    models = ns.model or ["logreg", "cart"]
+    models = ns.model or ["logreg", "cart", "random_forest"]
 
     sampler_map = {
         "smote": SMOTE,
@@ -76,6 +76,13 @@ def main(args: list[str] | None = None) -> None:
             print(f"Validation ROC-AUC: {gs.best_score_:.3f}")
         else:
             cart.main(ns.data_path, sampler)
+    if "random_forest" in models:
+        if ns.grid_search:
+            df = random_forest.load_data(ns.data_path)
+            gs = random_forest.grid_train_from_df(df, sampler=sampler)
+            print(f"Validation ROC-AUC: {gs.best_score_:.3f}")
+        else:
+            random_forest.main(ns.data_path, sampler)
 
 
 if __name__ == "__main__":

--- a/tests/test_random_forest.py
+++ b/tests/test_random_forest.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+from src.models.random_forest import train_from_df
+from src import dataprep
+from src.features import FeatureEngineer
+
+
+def _toy_df(n: int = 40) -> pd.DataFrame:
+    rng = np.random.default_rng(3)
+    df = pd.DataFrame(
+        {
+            "income_annum": rng.normal(200_000, 50_000, n),
+            "loan_amount": rng.normal(100_000, 20_000, n),
+            "loan_term": rng.integers(6, 24, n),
+            "cibil_score": rng.integers(600, 750, n),
+            "education": rng.choice(["Graduate", "Not Graduate"], n),
+            "self_employed": rng.choice(["Yes", "No"], n),
+            "residential_assets_value": rng.uniform(50_000, 150_000, n),
+            "commercial_assets_value": rng.uniform(0, 100_000, n),
+            "luxury_assets_value": rng.uniform(0, 50_000, n),
+            "bank_asset_value": rng.uniform(0, 50_000, n),
+            "gender": rng.choice(["M", "F"], n),
+            "married": rng.choice(["Yes", "No"], n),
+            "property_area": rng.choice(["Urban", "Rural", "Semiurban"], n),
+            "no_of_dependents": rng.integers(0, 4, n),
+            "target": rng.integers(0, 2, n),
+        }
+    )
+    return df
+
+
+def test_train_random_forest() -> None:
+    df = _toy_df()
+    df = dataprep.clean(df)
+    df = FeatureEngineer().transform(df)
+    auc = train_from_df(df, "target")
+    assert 0 <= auc <= 1


### PR DESCRIPTION
## Summary
- implement random forest pipeline with training and grid-search
- expose new model in `src.models`
- allow `mlcls-train` to run random forest
- add tests for the new model
- document the pipeline in the README, docs, and AGENTS
- log progress in NOTES and tick TODO

## Testing
- `flake8`
- `black --check .`
- `pytest -q`
- `sphinx-build -b html docs docs/_build`
- ⚠️ `pre-commit` failed due to missing network credentials

------
https://chatgpt.com/codex/tasks/task_e_684d73696cc48325b59d752c5c4023b4