### PR TITLE
Document random forest grid search

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -345,3 +345,6 @@ documentation in README. Updated AGENTS accordingly.
 2025-08-29: Added random_forest model mirroring logreg/cart with CLI support,
 tests and documentation. Reason: extend modelling options. Decisions: use
 RandomForestClassifier with simple grid search and expose via train.py.
+
+2025-08-30: Documented random_forest grid search example in docs and README.
+Reason: clarify advanced training options.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ make eval             # evaluate trained models and check fairness
 make train-logreg
 make train-cart
 mlcls-train --model random_forest  # train only the RF model
+mlcls-train --model random_forest -g  # grid search for the RF model
 mlcls-train --sampler smote   # run with SMOTE oversampling
 ```
 
@@ -166,7 +167,7 @@ After installing the project in editable mode you get two console commands:
 ```bash
 pip install -e .
 mlcls-train          # trains both models
-mlcls-train -g       # extensive grid search
+mlcls-train --model random_forest -g  # extensive grid search
 mlcls-eval           # evaluates the trained models
 mlcls-predict        # generates predictions from a saved model
 mlcls-report        # collects report artifacts

--- a/TODO.md
+++ b/TODO.md
@@ -226,3 +226,4 @@ scaling.
 
 - [x] add GitHub Pages workflow building Sphinx HTML and deploying to
   `gh-pages`
+- [x] document random_forest grid search example in docs and README

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -8,8 +8,10 @@ Grid search
 -----------
 
 Run ``mlcls-train -g`` to search a wider range of parameters. The job records
-metrics for each candidate and stores the best estimator under
-``artefacts/``.
+metrics for each candidate and stores the best estimator under ``artefacts/``.
+To perform grid search on the random-forest pipeline pass the model option::
+
+   mlcls-train --model random_forest -g
 
 Calibration
 -----------

--- a/docs/cli_usage.rst
+++ b/docs/cli_usage.rst
@@ -9,7 +9,7 @@ Train models and store artefacts under ``artefacts/``::
 
    mlcls-train --model logreg
    mlcls-train --model random_forest
-   mlcls-train -g  # grid search
+   mlcls-train --model random_forest -g  # grid search
 
 Evaluate metrics and write ``artefacts/summary_metrics.csv``::
 


### PR DESCRIPTION
## Summary
- document RF grid search in docs/advanced_usage.rst
- show `mlcls-train --model random_forest -g` usage in README and cli docs
- record the docs update in NOTES and TODO

## Testing
- `npx -y markdownlint-cli '**/*.md' --ignore node_modules`

------
https://chatgpt.com/codex/tasks/task_e_684d771e300883259369205edf78e486