### PR TITLE
Update CI guidelines

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -2,5 +2,6 @@
   "ignorePatterns": [
     { "pattern": "linkedin.com" }
     ,{ "pattern": "github\\.com/.*/actions" }
+    ,{ "pattern": "ivanstarostin1984.github.io" }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,6 +154,8 @@ ML_classification/
   CI workflow for verification.
 - Black uses a line length of **88** as configured in `pyproject.toml`.
 - Docs-only commits run a fast job with `markdownlint`.
+- Markdown-only commits skip the full test suite and run `markdownlint`
+  plus the link checker instead.
 - After tests pass, CI builds the Sphinx docs and uploads them using
   `actions/upload-artifact@v4`. Keep the major version current when GitHub
   releases a new one.

--- a/NOTES.md
+++ b/NOTES.md
@@ -353,3 +353,5 @@ RandomForestClassifier with simple grid search and expose via train.py.
 
 2025-08-30: Documented random_forest grid search example in docs and README.
 Reason: clarify advanced training options.
+2025-08-31: Documented that Markdown-only commits run markdownlint and link
+check instead of full tests in AGENTS.md. Reason: clarify CI behaviour.


### PR DESCRIPTION
## Summary
- clarify markdown-only CI steps in `AGENTS.md`
- note docs-only CI behaviour in `NOTES.md`
- ignore docs site in link checker config

## Testing
- `npx -y markdownlint-cli '**/*.md' --ignore node_modules`
- `find . -name '*.md' -not -path '*node_modules*' -print0 | xargs -0 -n1 npx -y markdown-link-check -q -c .markdown-link-check.json`

------
https://chatgpt.com/codex/tasks/task_e_684d7c68250c832583c66159537e1b9f