### PR TITLE
Add gradient boosting model

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -365,3 +365,5 @@ confirmed with markdownlint. Reason: keep docs compliant with style guide.
 
 2025-08-31: Documented that Markdown-only commits run markdownlint and link
 check instead of full tests in AGENTS.md. Reason: clarify CI behaviour.
+
+2025-08-31: Added gradient boosting model and CLI option with grid search tests. Reason: extend modelling options.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ make train-logreg
 make train-cart
 mlcls-train --model random_forest  # train only the RF model
 mlcls-train --model random_forest -g  # grid search for the RF model
+mlcls-train --model gboost  # train the gradient boosting model
+mlcls-train --model gboost -g  # grid search for gradient boosting
 mlcls-train --sampler smote   # run with SMOTE oversampling
 ```
 
@@ -169,6 +171,7 @@ After installing the project in editable mode you get two console commands:
 pip install -e .
 mlcls-train          # trains both models
 mlcls-train --model random_forest -g  # extensive grid search
+mlcls-train --model gboost -g  # gradient boosting grid search
 mlcls-eval           # evaluates the trained models
 mlcls-predict        # generates predictions from a saved model
 mlcls-report        # collects report artifacts
@@ -218,6 +221,7 @@ src/                     ← Python package skeleton
 src/models/logreg.py     ← logistic regression pipeline
 src/models/cart.py       ← decision-tree pipeline
 src/models/random_forest.py ← random-forest pipeline
+src/models/gradient_boosting.py ← gradient boosting pipeline
 src/features.py          ← FeatureEngineer class
 src/diagnostics.py       ← chi-square & correlation plots
 src/preprocessing.py     ← ColumnTransformer helpers

--- a/TODO.md
+++ b/TODO.md
@@ -228,3 +228,4 @@ scaling.
 - [x] add GitHub Pages workflow building Sphinx HTML and deploying to
   `gh-pages`
 - [x] document random_forest grid search example in docs and README
+- [ ] add gradient boosting model and CLI option with grid search

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -12,6 +12,7 @@ metrics for each candidate and stores the best estimator under ``artefacts/``.
 To perform grid search on the random-forest pipeline pass the model option::
 
    mlcls-train --model random_forest -g
+   mlcls-train --model gboost -g
 
 Calibration
 -----------

--- a/docs/cli_usage.rst
+++ b/docs/cli_usage.rst
@@ -10,6 +10,8 @@ Train models and store artefacts under ``artefacts/``::
    mlcls-train --model logreg
    mlcls-train --model random_forest
    mlcls-train --model random_forest -g  # grid search
+   mlcls-train --model gboost
+   mlcls-train --model gboost -g  # grid search
 
 Evaluate metrics and write ``artefacts/summary_metrics.csv``::
 

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,5 +1,5 @@
 """Model training pipelines."""
 
-from . import logreg, cart, random_forest
+from . import logreg, cart, random_forest, gradient_boosting
 
-__all__ = ["logreg", "cart", "random_forest"]
+__all__ = ["logreg", "cart", "random_forest", "gradient_boosting"]

--- a/src/models/gradient_boosting.py
+++ b/src/models/gradient_boosting.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import joblib
+import pandas as pd
+from imblearn.base import SamplerMixin
+from imblearn.pipeline import Pipeline
+from sklearn.ensemble import GradientBoostingClassifier
+from sklearn.metrics import roc_auc_score
+
+from ..dataprep import clean
+from ..features import FeatureEngineer
+from ..preprocessing import build_preprocessor, validate_prep
+from ..pipeline_helpers import tree_steps, run_gs
+from ..split import stratified_split
+
+DATA_PATH = Path("data/raw/loan_approval_dataset.csv")
+TARGET = "loan_status"
+
+
+def load_data(path: str | Path = DATA_PATH) -> pd.DataFrame:
+    """Return cleaned and engineered DataFrame loaded from ``path``."""
+    df = pd.read_csv(Path(path))
+    df = clean(df)
+    return FeatureEngineer().transform(df)
+
+
+def build_pipeline(
+    cat_cols: list[str], num_cols: list[str], sampler: SamplerMixin | None = None
+) -> Pipeline:
+    """Create preprocessing and gradient-boosting pipeline."""
+    preproc = build_preprocessor(num_cols, cat_cols)
+    model = GradientBoostingClassifier(random_state=42)
+    steps = [("prep", preproc)]
+    if sampler is not None:
+        steps.append(("sampler", sampler))
+    steps.append(("model", model))
+    return Pipeline(steps)
+
+
+def train_from_df(
+    df: pd.DataFrame,
+    target: str = TARGET,
+    artefact_path: Path | None = None,
+    sampler: SamplerMixin | None = None,
+) -> float:
+    """Train model on ``df`` and return validation ROC-AUC."""
+    train_df, val_df, _ = stratified_split(df, target)
+    x_train = train_df.drop(columns=[target])
+    y_train = train_df[target]
+    x_val = val_df.drop(columns=[target])
+    y_val = val_df[target]
+    cat_cols = x_train.select_dtypes(include=["object", "category"]).columns.tolist()
+    num_cols = [c for c in x_train.columns if c not in cat_cols]
+    pipe = build_pipeline(cat_cols, num_cols, sampler)
+    pipe.named_steps["prep"].fit(x_train, y_train)
+    validate_prep(pipe.named_steps["prep"], x_train, "gboost")
+    pipe.fit(x_train, y_train)
+    pred = pipe.predict_proba(x_val)[:, 1]
+    auc = roc_auc_score(y_val, pred)
+    if artefact_path:
+        artefact_path.parent.mkdir(parents=True, exist_ok=True)
+        joblib.dump(pipe, artefact_path)
+    return auc
+
+
+def grid_train_from_df(
+    df: pd.DataFrame,
+    target: str = TARGET,
+    artefact_path: Path | None = None,
+    sampler: SamplerMixin | None = None,
+):
+    """Return fitted GridSearchCV and optionally save best model."""
+    x, y = df.drop(columns=[target]), df[target]
+    cat_cols = x.select_dtypes(include=["object", "category"]).columns.tolist()
+    num_cols = [c for c in x.columns if c not in cat_cols]
+    preproc = build_preprocessor(num_cols, cat_cols)
+    preproc.fit(x, y)
+    validate_prep(preproc, x, "gboost")
+    steps = tree_steps(preproc, sampler or "passthrough")
+    grid = {
+        "model__n_estimators": [100, 200],
+        "model__learning_rate": [0.05, 0.1],
+        "model__max_depth": [3, 5],
+        "model__min_samples_split": [2, 4],
+        "model__min_samples_leaf": [1, 2],
+    }
+    gs = run_gs(x, y, steps, GradientBoostingClassifier(random_state=42), grid)
+    if artefact_path:
+        artefact_path.parent.mkdir(parents=True, exist_ok=True)
+        joblib.dump(gs.best_estimator_, artefact_path)
+    return gs
+
+
+def main(
+    data_path: str | Path = DATA_PATH, sampler: SamplerMixin | None = None
+) -> None:
+    df = load_data(data_path)
+    auc = train_from_df(
+        df, artefact_path=Path("artefacts/gboost.joblib"), sampler=sampler
+    )
+    print(f"Validation ROC-AUC: {auc:.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/train.py
+++ b/src/train.py
@@ -7,7 +7,7 @@ from imblearn.over_sampling import RandomOverSampler, SMOTE, SMOTEN, SMOTENC
 from imblearn.under_sampling import RandomUnderSampler
 from imblearn.combine import SMOTETomek
 
-from .models import logreg, cart, random_forest
+from .models import logreg, cart, random_forest, gradient_boosting
 
 
 def main(args: list[str] | None = None) -> None:
@@ -17,7 +17,7 @@ def main(args: list[str] | None = None) -> None:
         "--model",
         "-m",
         action="append",
-        choices=["logreg", "cart", "random_forest"],
+        choices=["logreg", "cart", "random_forest", "gboost"],
         help="models to train; defaults to all",
     )
     parser.add_argument(
@@ -46,7 +46,7 @@ def main(args: list[str] | None = None) -> None:
         help="use grid search to tune hyperparameters",
     )
     ns = parser.parse_args(args)
-    models = ns.model or ["logreg", "cart", "random_forest"]
+    models = ns.model or ["logreg", "cart", "random_forest", "gboost"]
 
     sampler_map = {
         "smote": SMOTE,
@@ -83,6 +83,13 @@ def main(args: list[str] | None = None) -> None:
             print(f"Validation ROC-AUC: {gs.best_score_:.3f}")
         else:
             random_forest.main(ns.data_path, sampler)
+    if "gboost" in models:
+        if ns.grid_search:
+            df = gradient_boosting.load_data(ns.data_path)
+            gs = gradient_boosting.grid_train_from_df(df, sampler=sampler)
+            print(f"Validation ROC-AUC: {gs.best_score_:.3f}")
+        else:
+            gradient_boosting.main(ns.data_path, sampler)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli_gboost_gridsearch.py
+++ b/tests/test_cli_gboost_gridsearch.py
@@ -1,0 +1,58 @@
+import os
+import sys
+import subprocess
+import sysconfig
+from pathlib import Path
+
+import pandas as pd
+from sklearn.datasets import make_classification
+
+
+def _toy_df(n: int = 30) -> pd.DataFrame:
+    x, y = make_classification(
+        n_samples=n,
+        n_features=3,
+        n_informative=3,
+        n_redundant=0,
+        random_state=0,
+    )
+    return pd.DataFrame(
+        {
+            "loan_amount": abs(x[:, 0]) * 100 + 100,
+            "loan_term": (abs(x[:, 1]) * 10 + 10).astype(int),
+            "cibil_score": abs(x[:, 2]) * 100 + 500,
+            "Loan_Status": pd.Series(y).map({1: "Y", 0: "N"}),
+            "education": ["Graduate"] * n,
+            "self_employed": ["No"] * n,
+        }
+    )
+
+
+def test_train_gboost_gridsearch(tmp_path) -> None:
+    root = Path(__file__).resolve().parents[1]
+    subprocess.run(
+        [sys.executable, "-m", "pip", "install", "-e", str(root)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    df = _toy_df()
+    data_dir = tmp_path / "data" / "raw"
+    data_dir.mkdir(parents=True)
+    csv_path = data_dir / "loan_approval_dataset.csv"
+    df.to_csv(csv_path, index=False)
+
+    env = os.environ.copy()
+    scripts_dir = Path(sysconfig.get_path("scripts"))
+    env["PATH"] = str(scripts_dir) + os.pathsep + env.get("PATH", "")
+
+    res = subprocess.run(
+        ["mlcls-train", "--model", "gboost", "-g", "--data-path", str(csv_path)],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert "Validation ROC-AUC" in res.stdout

--- a/tests/test_gradient_boosting.py
+++ b/tests/test_gradient_boosting.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from src.models.gradient_boosting import train_from_df, grid_train_from_df
+import src.models.gradient_boosting as gboost
+from src import dataprep
+from src.features import FeatureEngineer
+
+
+def _toy_df(n: int = 40) -> pd.DataFrame:
+    rng = np.random.default_rng(4)
+    df = pd.DataFrame(
+        {
+            "income_annum": rng.normal(200_000, 50_000, n),
+            "loan_amount": rng.normal(100_000, 20_000, n),
+            "loan_term": rng.integers(6, 24, n),
+            "cibil_score": rng.integers(600, 750, n),
+            "education": rng.choice(["Graduate", "Not Graduate"], n),
+            "self_employed": rng.choice(["Yes", "No"], n),
+            "residential_assets_value": rng.uniform(50_000, 150_000, n),
+            "commercial_assets_value": rng.uniform(0, 100_000, n),
+            "luxury_assets_value": rng.uniform(0, 50_000, n),
+            "bank_asset_value": rng.uniform(0, 50_000, n),
+            "gender": rng.choice(["M", "F"], n),
+            "married": rng.choice(["Yes", "No"], n),
+            "property_area": rng.choice(["Urban", "Rural", "Semiurban"], n),
+            "no_of_dependents": rng.integers(0, 4, n),
+            "target": rng.integers(0, 2, n),
+        }
+    )
+    return df
+
+
+def test_train_gradient_boosting() -> None:
+    df = _toy_df()
+    df = dataprep.clean(df)
+    df = FeatureEngineer().transform(df)
+    auc = train_from_df(df, "target")
+    assert 0 <= auc <= 1
+
+
+def test_grid_train_from_df() -> None:
+    df = _toy_df()
+    df = dataprep.clean(df)
+    df = FeatureEngineer().transform(df)
+    gs = grid_train_from_df(df, "target")
+    assert len(gs.cv_results_["params"]) == 32
+    assert hasattr(gs, "best_estimator_")
+
+
+def test_grid_train_saves_best(tmp_path) -> None:
+    df = _toy_df()
+    df = dataprep.clean(df)
+    df = FeatureEngineer().transform(df)
+    fp = tmp_path / "model.joblib"
+    grid_train_from_df(df, "target", artefact_path=fp)
+    assert fp.exists()
+
+
+def test_validate_prep_called(monkeypatch) -> None:
+    df = _toy_df()
+    df = dataprep.clean(df)
+    df = FeatureEngineer().transform(df)
+    called = {}
+
+    def fake_validate(prep, X, name, check_scale=True):
+        called["ok"] = True
+
+    monkeypatch.setattr(gboost, "validate_prep", fake_validate)
+    grid_train_from_df(df, "target")
+    assert called.get("ok")


### PR DESCRIPTION
## Summary
- implement `src/models/gradient_boosting.py`
- expose gradient boosting through train CLI
- add unit and CLI tests
- document gradient boosting usage
- note the work in NOTES and TODO

## Testing
- `flake8`
- `black --check .`
- `pytest -q`
- `pre-commit` *(failed: requires GitHub credentials)*

------
https://chatgpt.com/codex/tasks/task_e_684d816cdf908325b46d605cd2eed8c8