### PR TITLE
Document SHAP plotting helper

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -372,3 +372,5 @@ tests. Reason: extend modelling options.
 feature_importance. Reason: user request to inspect model contributions.
 
 2025-09-01: Documented gradient boosting and SHAP modules in AGENTS.md.
+2025-09-02: Documented new plot_shap_summary helper in README and docs.
+Reason: show how to generate SHAP plots.

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ Training produces feature-importance tables (`logreg_coefficients.csv`,
 are recorded in `artefacts/SHA256_manifest.txt` for reproducibility.
 Pass a DataFrame to `logreg_coefficients` or `tree_feature_importances`
 along with `shap_csv_path` to save SHAP value tables as well.
+Use `plot_shap_summary` to turn those values into a PNG stored in
+`artefacts/`.
 
 `make eval` runs `python -m src.evaluate` to compute test metrics and the worst
 four-fifths ratio across protected groups (pass `--group-col` to override the

--- a/TODO.md
+++ b/TODO.md
@@ -229,6 +229,6 @@ scaling.
   `gh-pages`
 - [x] document random_forest grid search example in docs and README
 - [x] add gradient boosting model and CLI option with grid search
-- [ ] add SHAP value visualisation for feature importance
+- [x] add SHAP value visualisation for feature importance
 
 - [x] update AGENTS.md with gradient_boosting and shap_utils entries

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -63,3 +63,18 @@ and pass ``shap_csv_path`` to store per-feature SHAP values::
 
 The helper function ``compute_shap_values`` creates the table with columns
 matching the input DataFrame.
+
+SHAP plots
+----------
+
+Use ``plot_shap_summary`` to visualise these values::
+
+   from src.feature_importance import plot_shap_summary
+
+   plot_shap_summary(
+       "artefacts/lr.joblib",
+       X=X_test,
+       png_path="artefacts/logreg_shap.png",
+   )
+
+The image ``logreg_shap.png`` appears under ``artefacts/``.


### PR DESCRIPTION
## Summary
- document `plot_shap_summary` helper in advanced usage
- mention SHAP plotting in README near coefficient helpers
- log the docs change and tick TODO

## Testing
- `npx markdownlint-cli '**/*.md' --ignore node_modules`
- `make lint-docs`

------
https://chatgpt.com/codex/tasks/task_e_684e9514482483259494efb7cef48f22