### PR TITLE
Fix NOTES formatting for line length

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -373,7 +373,8 @@ feature_importance. Reason: user request to inspect model contributions.
 
 2025-09-01: Documented gradient boosting and SHAP modules in AGENTS.md.
 
-2025-09-02: Documented plot_or_load helper and SHAP PNG size limit in AGENTS. Mentioned running markdownlint after doc edits.
+2025-09-02: Documented plot_or_load helper and SHAP PNG size limit in AGENTS.
+Mentioned running markdownlint after doc edits.
 
 2025-09-02: Added plot_shap_summary saving SHAP bar plots, integrated optional
 shap_png_path into feature_importance and wrote tests for PNG outputs. Reason:
@@ -381,3 +382,6 @@ complete TODO for SHAP visualisation.
 
 2025-09-02: Documented new plot_shap_summary helper in README and docs.
 Reason: show how to generate SHAP plots.
+
+2025-09-03: Split long doc entry about plot_or_load and markdownlint into two lines.
+Reason: keep NOTES under 80 characters as per guidelines.


### PR DESCRIPTION
## Summary
- split long entry about the `plot_or_load` documentation into two lines
- append note on the change in `NOTES.md`

## Testing
- `npx -y markdownlint-cli '**/*.md' --ignore node_modules`

------
https://chatgpt.com/codex/tasks/task_e_684e9e58234c83259ba2a208a975978f