### PR TITLE
Update pre-commit token docs

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -401,3 +401,5 @@ docs. Reason: extend fairness metrics per TODO.
 
 2025-09-04: README and docs index link CITATION.cff so users know how to cite.
 Reason: surface citation metadata.
+2025-09-07: README states pre-commit needs network access or a GIT_TOKEN.
+Token with public_repo scope can be kept as a CI secret. Reason: clarify setup.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ pip install -e .
 pip install pre-commit
 pre-commit install
 
+# Running pre-commit needs network access or a `GIT_TOKEN` with
+# at least the `public_repo` scope. Store the token as a secret and
+# reference it in CI.
+
 # The hooks run `isort` before `black` and `flake8` so imports stay ordered.
 # In CI the workflow runs `pre-commit run --files` on changed files before
 # `flake8`, `black` and `pytest`.

--- a/TODO.md
+++ b/TODO.md
@@ -239,6 +239,8 @@ scaling.
 - [x] clarify GIT_TOKEN note with required PAT scopes
 - [x] add bullet that gh-pages push needs a token with contents:write
 
+- [x] document storing GIT_TOKEN as secret for pre-commit in CI
+
 ## 23. Release notes
 
 - [ ] update CHANGELOG.md with release notes on each version bump


### PR DESCRIPTION
## Summary
- clarify that running pre-commit needs network access or a token
- note that the token can be stored as a CI secret
- track the clarification in TODO and NOTES

## Testing
- `npx -y markdownlint-cli '**/*.md' --ignore node_modules` *(failed: npm warn Unknown env config)*
- `find . -name '*.md' -not -path '*node_modules*' -print0 | xargs -0 -n1 npx markdown-link-check -q` *(failed: 3 dead links in README)*

------
https://chatgpt.com/codex/tasks/task_e_684ead87d58c8325a3b41233424a2b6c