### PR TITLE
Release 0.1.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,7 +211,8 @@ to track work.
 - Binder support lives in `binder/` with an `environment.yml` referencing the
   project requirements and a `postBuild` script installing the package in
   editable mode.
-- Record release notes in `CHANGELOG.md` whenever the version number changes.
+- Whenever you bump `pyproject.toml`'s version, add a section in `CHANGELOG.md`
+  summarising the changes.
 
 Read `NOTES.md` and `TODO.md` to understand the current stage, past decisions,
 and open questions tied to the spec.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,9 @@
 - SHAP visualisation helper for feature importance.
 - Binder environment, Dockerfile and Makefile for reproducible runs.
 - CI workflow running linting and tests plus Sphinx documentation.
+
+## 0.1.1 - YYYY-MM-DD
+
+- Documented that pre-commit requires network access or a GIT_TOKEN.
+- Linked CITATION.cff from README and docs.
+- Added equalized_odds_diff metric with eq_odds column.

--- a/NOTES.md
+++ b/NOTES.md
@@ -403,3 +403,7 @@ docs. Reason: extend fairness metrics per TODO.
 Reason: surface citation metadata.
 2025-09-07: README states pre-commit needs network access or a GIT_TOKEN.
 Token with public_repo scope can be kept as a CI secret. Reason: clarify setup.
+
+2025-09-08: Bumped version to 0.1.1 and updated CHANGELOG with token docs,
+CITATION link and equalized odds metric.
+Decision: emphasise version rule in AGENTS.

--- a/TODO.md
+++ b/TODO.md
@@ -243,4 +243,4 @@ scaling.
 
 ## 23. Release notes
 
-- [ ] update CHANGELOG.md with release notes on each version bump
+- [x] update CHANGELOG.md with release notes on each version bump

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ml-classification"
-version = "0.1.0"
+version = "0.1.1"
 description = "Loan-approval prediction pipelines"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- bump project version to 0.1.1
- add release notes for 0.1.1
- log the release in NOTES
- tick the release notes TODO item
- clarify in AGENTS that version bumps need a CHANGELOG entry

## Testing
- `npx -y markdownlint-cli '**/*.md' --ignore node_modules`
- `flake8`
- `black --check .`
- `pytest -q`
- `pre-commit run --files AGENTS.md CHANGELOG.md NOTES.md TODO.md pyproject.toml` *(failed: prompted for GitHub credentials)*

------
https://chatgpt.com/codex/tasks/task_e_684eba97faf083259f9915cf9df164ae