### PR TITLE
Update Binder docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,6 +211,9 @@ to track work.
 - Binder support lives in `binder/` with an `environment.yml` referencing the
   project requirements and a `postBuild` script installing the package in
   editable mode.
+- Binder sessions start without the Kaggle dataset and cannot download
+  it because no credentials are provided. Upload the CSV files manually
+  if you need them during a demo.
 - Whenever you bump `pyproject.toml`'s version, add a section in `CHANGELOG.md`
   summarising the changes.
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -407,3 +407,8 @@ Token with public_repo scope can be kept as a CI secret. Reason: clarify setup.
 2025-09-08: Bumped version to 0.1.1 and updated CHANGELOG with token docs,
 CITATION link and equalized odds metric.
 Decision: emphasise version rule in AGENTS.
+
+2025-06-16: Documented Binder limitation that the Kaggle dataset is
+absent and cannot be downloaded without credentials. Updated Binder
+sections in README, notebooks README, docs index and AGENTS.
+Reason: avoid confusion when running demos online.

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ Interactive notebooks live under `notebooks/`. Open `loan_demo.ipynb` or
 `advanced_demo.ipynb` for a guided walkthrough.
 You can also launch them instantly on Binder via the badge in
 `notebooks/README.md`.
+Binder sessions do not ship with the Kaggle dataset and cannot download
+it without credentials.
 
 Training produces feature-importance tables (`logreg_coefficients.csv`,
 `cart_importances.csv`) and bar-chart PNGs in `artefacts/`. All generated files

--- a/TODO.md
+++ b/TODO.md
@@ -214,6 +214,8 @@ scaling.
 - [x] add binder/environment.yml referencing requirements
 - [x] create postBuild script to install package in editable mode
 - [x] update docs if binder instructions change
+- [x] document that Binder sessions lack the Kaggle dataset and
+      cannot download it without credentials
 
 ## 20. Data caching
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,6 +4,8 @@ Welcome to ML_classification's documentation
 See :doc:`advanced_usage` for steps on fairness checks and calibration. See the
 Binder badge in :file:`notebooks/README.md` for a quick start running the demo
 notebooks online.
+These Binder sessions do not include the Kaggle dataset and
+cannot download it without credentials.
 
 For citation instructions see :file:`../CITATION.cff`.
 

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -29,3 +29,7 @@ You can also open the notebooks directly in Google Colab via the GitHub link.
 Alternatively launch them in Binder:
 
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/IvanStarostin1984/ML_classification/HEAD?labpath=notebooks%2Floan_demo.ipynb)
+
+**Note:** Binder sessions start without the Kaggle dataset and cannot
+download it unless you provide credentials. Upload the CSV files
+manually if you want to run the notebooks online.


### PR DESCRIPTION
## Summary
- document that Binder sessions are missing the Kaggle dataset
- note the same in docs index and contributor guidelines
- mention dataset limitation in repo README and notebooks README
- log changes in NOTES and TODO

## Testing
- `npx -y markdownlint-cli '**/*.md' --ignore node_modules`
- `find . -name '*.md' -not -path '*node_modules*' -print0 | xargs -0 -n1 npx -y markdown-link-check -q -c .markdown-link-check.json`

------
https://chatgpt.com/codex/tasks/task_e_684fbc2bd78083258a2248fe44d9d20d