### PR TITLE
Clean TODO note about markdown hook

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -421,3 +421,6 @@ Tests and docs cover it. Reason: allow custom cutoff in fairness metrics.
 absent and cannot be downloaded without credentials. Updated Binder
 sections in README, notebooks README, docs index and AGENTS.
 Reason: avoid confusion when running demos online.
+
+2025-09-10: Removed TODO item about running a pre-commit hook for markdownlint.
+Reason: docs rely on CI gate only.

--- a/TODO.md
+++ b/TODO.md
@@ -43,7 +43,6 @@ src.models.logreg`)
 - [x] add unit tests for `split.stratified_split`
 - [x] add docs-only CI job running markdownlint and markdown-link-check
 - [x] fix link check step to iterate over markdown files with find/xargs
-- [x] Add pre-commit hook or make target with `npx markdownlint-cli` for MD012.
 - [x] Run `pre-commit run --files` in CI before flake8, black and pytest
 
 ## 6. Documentation updates


### PR DESCRIPTION
## Summary
- drop the old TODO entry about a markdownlint pre‑commit hook
- record the docs update in NOTES

## Testing
- `npx markdownlint-cli '**/*.md' --ignore node_modules` *(fails: Need to install packages)*

------
https://chatgpt.com/codex/tasks/task_e_684fc79d441c8325a7bc6ce8d6df3fca