### PR TITLE
Refactor model modules to reuse CSV_PATH

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -431,3 +431,5 @@ updated. Reason: expose artifact verification.
 2025-09-11: Added example in advanced_usage showing mlcls-report saving
 artifacts under report_artifacts/ and noted zipping for sharing. Updated
 index with reference and ticked TODO. Reason: clarify reporting workflow.
+
+2025-06-16: Model pipelines import CSV_PATH and reuse it as DATA_PATH. Reason: centralise default data path.

--- a/TODO.md
+++ b/TODO.md
@@ -252,3 +252,7 @@ scaling.
 ## 24. Report docs
 
 - [x] show mlcls-report example in advanced_usage and note zipping output
+
+## 25. Data path refactor
+
+- [x] centralise DATA_PATH via CSV_PATH constant in model modules

--- a/src/models/cart.py
+++ b/src/models/cart.py
@@ -10,13 +10,13 @@ from imblearn.pipeline import Pipeline
 from sklearn.tree import DecisionTreeClassifier
 from sklearn.model_selection import GridSearchCV
 
-from ..dataprep import clean
+from ..dataprep import clean, CSV_PATH
 from ..features import FeatureEngineer
 from ..preprocessing import build_preprocessor, validate_prep
 from ..pipeline_helpers import tree_steps, run_gs
 from ..split import stratified_split
 
-DATA_PATH = Path("data/raw/loan_approval_dataset.csv")
+DATA_PATH = CSV_PATH
 TARGET = "loan_status"
 
 

--- a/src/models/gradient_boosting.py
+++ b/src/models/gradient_boosting.py
@@ -9,13 +9,13 @@ from imblearn.pipeline import Pipeline
 from sklearn.ensemble import GradientBoostingClassifier
 from sklearn.metrics import roc_auc_score
 
-from ..dataprep import clean
+from ..dataprep import clean, CSV_PATH
 from ..features import FeatureEngineer
 from ..preprocessing import build_preprocessor, validate_prep
 from ..pipeline_helpers import tree_steps, run_gs
 from ..split import stratified_split
 
-DATA_PATH = Path("data/raw/loan_approval_dataset.csv")
+DATA_PATH = CSV_PATH
 TARGET = "loan_status"
 
 

--- a/src/models/logreg.py
+++ b/src/models/logreg.py
@@ -12,7 +12,7 @@ from imblearn.base import SamplerMixin
 from imblearn.pipeline import Pipeline
 from imblearn.over_sampling import SMOTE, SMOTENC
 
-from ..dataprep import clean
+from ..dataprep import clean, CSV_PATH
 from ..features import FeatureEngineer
 from ..preprocessing import build_preprocessor, validate_prep
 
@@ -20,7 +20,7 @@ from ..pipeline_helpers import lr_steps, run_gs
 
 from ..split import stratified_split
 
-DATA_PATH = Path("data/raw/loan_approval_dataset.csv")
+DATA_PATH = CSV_PATH
 TARGET = "loan_status"
 
 # logistic regression hyper-parameter blocks (sampler added dynamically)

--- a/src/models/random_forest.py
+++ b/src/models/random_forest.py
@@ -9,13 +9,13 @@ from sklearn.metrics import roc_auc_score
 from imblearn.base import SamplerMixin
 from imblearn.pipeline import Pipeline
 
-from ..dataprep import clean
+from ..dataprep import clean, CSV_PATH
 from ..features import FeatureEngineer
 from ..preprocessing import build_preprocessor, validate_prep
 from ..pipeline_helpers import tree_steps, run_gs
 from ..split import stratified_split
 
-DATA_PATH = Path("data/raw/loan_approval_dataset.csv")
+DATA_PATH = CSV_PATH
 TARGET = "loan_status"
 
 


### PR DESCRIPTION
## Summary
- centralise `DATA_PATH` in model pipelines by reusing `CSV_PATH` from `dataprep`
- document the change in `NOTES.md` and `TODO.md`

## Testing
- `pre-commit` *(fails: authentication to GitHub needed)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fd7971b5883258afc7f8e24d4cb1d