### PR TITLE
Add dataset summary CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,7 @@ ML_classification/
 └─ README.md # badges, quick-start, results, contact
 
 - CLI `mlcls-eval` accepts `--threshold` to set group metric cutoff
+- CLI `mlcls-summary` prints dataset row/column counts and class balance
 
 ## Coding Standards
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -436,3 +436,5 @@ index with reference and ticked TODO. Reason: clarify reporting workflow.
 Reason: document custom cutoff for group metrics.
 
 2025-06-16: Model pipelines import CSV_PATH and reuse it as DATA_PATH. Reason: centralise default data path.
+
+2025-09-13: Added mlcls-summary CLI for dataset stats (rows, cols, balance). Reason: implement TODO item for quick overview. Decisions: compute stats on cleaned data.

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ mlcls-eval --threshold 0.6  # sets fairness metric cutoff
 mlcls-predict        # generates predictions from a saved model
 mlcls-report        # collects report artifacts
 mlcls-manifest      # writes checksums for selected files
+mlcls-summary       # prints dataset statistics
 ```
 
 These commands require the Kaggle dataset, which is distributed under its

--- a/TODO.md
+++ b/TODO.md
@@ -256,3 +256,7 @@ scaling.
 ## 25. Data path refactor
 
 - [x] centralise DATA_PATH via CSV_PATH constant in model modules
+
+## 26. Dataset summary CLI
+
+- [x] expose mlcls-summary command printing dataset rows, columns and class balance

--- a/docs/cli_usage.rst
+++ b/docs/cli_usage.rst
@@ -32,6 +32,10 @@ Create a checksum manifest::
 
    mlcls-manifest artefacts/*.csv
 
+Show dataset statistics::
+
+   mlcls-summary --data-path data/raw/loan_approval_dataset.csv
+
 The command gathers recent metrics and plots under ``report_artifacts/``. This
 folder can be zipped and shared as a summary of the run.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ mlcls-eval = "src.evaluate:main"
 mlcls-predict = "src.predict:main"
 mlcls-report = "src.reporting:main"
 mlcls-manifest = "src.manifest:main"
+mlcls-summary = "src.summary:main"
 
 [tool.setuptools]
 packages = ["src", "scripts"]

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -36,4 +36,5 @@ __all__ = [
     "logreg_coefficients",
     "tree_feature_importances",
     "write_manifest",
+    "dataset_summary",
 ]

--- a/src/summary.py
+++ b/src/summary.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+
+from . import dataprep
+
+__all__ = ["dataset_summary", "main"]
+
+
+def dataset_summary(df: pd.DataFrame, target: str = "Loan_Status") -> str:
+    """Return a short dataset overview string."""
+    rows, cols = df.shape
+    parts = [f"Rows: {rows}", f"Columns: {cols}"]
+    if target in df.columns:
+        counts = df[target].value_counts()
+        total = counts.sum()
+        stats = []
+        for cls, cnt in counts.items():
+            pct = cnt / total * 100
+            stats.append(f"{cls}: {cnt} ({pct:.1f}%)")
+        parts.append("Class balance: " + ", ".join(stats))
+    return "\n".join(parts)
+
+
+def main(args: list[str] | None = None) -> None:
+    """CLI entry point printing dataset statistics."""
+    parser = argparse.ArgumentParser(description="Print dataset statistics")
+    parser.add_argument(
+        "--data-path",
+        type=Path,
+        default=dataprep.CSV_PATH,
+        help="CSV dataset path",
+    )
+    parser.add_argument(
+        "--target",
+        default="Loan_Status",
+        help="target column name",
+    )
+    ns = parser.parse_args(args)
+    df = dataprep.clean(dataprep.load_raw(ns.data_path))
+    print(dataset_summary(df, ns.target))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import os
+import sys
+import subprocess
+import sysconfig
+from pathlib import Path
+
+import pandas as pd
+from sklearn.datasets import make_classification
+
+
+def _toy_df(n: int = 30) -> pd.DataFrame:
+    x, y = make_classification(
+        n_samples=n,
+        n_features=3,
+        n_informative=3,
+        n_redundant=0,
+        random_state=0,
+    )
+    return pd.DataFrame(
+        {
+            "loan_amount": abs(x[:, 0]) * 100 + 100,
+            "loan_term": (abs(x[:, 1]) * 10 + 10).astype(int),
+            "cibil_score": abs(x[:, 2]) * 100 + 500,
+            "Loan_Status": pd.Series(y).map({1: "Y", 0: "N"}),
+            "education": ["Graduate"] * n,
+            "self_employed": ["No"] * n,
+        }
+    )
+
+
+def test_cli_summary(tmp_path) -> None:
+    root = Path(__file__).resolve().parents[1]
+    subprocess.run(
+        [sys.executable, "-m", "pip", "install", "-e", str(root)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    df = _toy_df()
+    data_dir = tmp_path / "data" / "raw"
+    data_dir.mkdir(parents=True)
+    csv_path = data_dir / "loan_approval_dataset.csv"
+    df.to_csv(csv_path, index=False)
+
+    env = os.environ.copy()
+    scripts_dir = Path(sysconfig.get_path("scripts"))
+    env["PATH"] = str(scripts_dir) + os.pathsep + env.get("PATH", "")
+
+    res = subprocess.run(
+        ["mlcls-summary", "--data-path", str(csv_path)],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    out = res.stdout
+    assert "Rows: 30" in out
+    assert "Columns: 6" in out
+    assert "1: 15" in out
+    assert "0: 15" in out


### PR DESCRIPTION
## Summary
- add `src/summary.py` providing dataset stats and CLI
- expose `mlcls-summary` entry point
- document usage in README and docs
- test CLI on a small sample
- log notes and tick TODO
- mention new command in AGENTS

## Testing
- `flake8 src/summary.py tests/test_summary.py`
- `black --check src/summary.py tests/test_summary.py src/__init__.py`
- `pytest -q tests/test_summary.py`
- `pre-commit` failed due to missing GitHub auth

------
https://chatgpt.com/codex/tasks/task_e_684ff1cb410c832583a47b3fd5c8f257