### PR TITLE
Fix pre-commit isort args

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: 6.0.1
     hooks:
       - id: isort
-        profile: black
+        args: ['--profile', 'black']
   - repo: https://github.com/psf/black
     rev: 23.7.0
     hooks:

--- a/NOTES.md
+++ b/NOTES.md
@@ -448,9 +448,14 @@ Reason: centralise default data path.
 2025-06-16: Added SVM model with grid search, CLI option and tests. Updated docs
 and AGENTS. Reason: expand modelling options per TODO.
 
-2025-06-16: Model pipelines import CSV_PATH and reuse it as DATA_PATH. 
+2025-06-16: Model pipelines import CSV_PATH and reuse it as DATA_PATH.
 Reason: centralise default data path.
 
-2025-09-13: Added mlcls-summary CLI for dataset stats (rows, cols, balance). 
-Reason: implement TODO item for quick overview. 
+2025-09-13: Added mlcls-summary CLI for dataset stats (rows, cols, balance).
+Reason: implement TODO item for quick overview.
 Decisions: compute stats on cleaned data.
+
+2025-09-14: Updated isort hook in pre-commit config to use
+`args: ['--profile', 'black']` as required by isort 6. Attempted to
+run `pre-commit` but cloning hook repos failed due to missing
+GitHub token.

--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,4 @@
+
 # TODO: Modularise the Colab notebook
 
 All migration tasks are complete as of commit `8af97fc`. This checklist started
@@ -257,7 +258,6 @@ scaling.
 
 - [x] centralise DATA_PATH via CSV_PATH constant in model modules
 
-
 ## 26. Support vector machine model
 
 - [x] add SVM pipeline, CLI option and tests
@@ -265,4 +265,3 @@ scaling.
 ## 27. Dataset summary CLI
 
 - [x] expose mlcls-summary command printing dataset rows, columns and class balance
-


### PR DESCRIPTION
## Summary
- use new args syntax for isort hook
- update NOTES with rationale
- clean up TODO formatting

## Testing
- `npx -y markdownlint-cli '**/*.md' --ignore node_modules`
- `pre-commit run --files .pre-commit-config.yaml` *(fails: Username prompt)*

------
https://chatgpt.com/codex/tasks/task_e_684ffbf0b6008325b48cb9ea6611f4bb