### PR TITLE
docs: use GH_PAGES_TOKEN for gh-pages workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'IvanStarostin1984/ML_classification'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -22,6 +23,6 @@ jobs:
       - name: Deploy to gh-pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          personal_token: ${{ secrets.GH_PAGES_TOKEN }}
           publish_dir: docs/_build
           publish_branch: gh-pages

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,6 +184,7 @@ ML_classification/
   `gh-pages` branch using `peaceiris/actions-gh-pages@v3`.
   Pushing to this branch requires a token with `contents:write`
   (the default `GITHUB_TOKEN` on forks lacks this permission).
+- Store this token in the `GH_PAGES_TOKEN` secret for the docs job.
   Links are checked using:
 
 ```bash

--- a/NOTES.md
+++ b/NOTES.md
@@ -448,9 +448,12 @@ Reason: centralise default data path.
 2025-06-16: Added SVM model with grid search, CLI option and tests. Updated docs
 and AGENTS. Reason: expand modelling options per TODO.
 
-2025-06-16: Model pipelines import CSV_PATH and reuse it as DATA_PATH. 
+2025-06-16: Model pipelines import CSV_PATH and reuse it as DATA_PATH.
 Reason: centralise default data path.
 
-2025-09-13: Added mlcls-summary CLI for dataset stats (rows, cols, balance). 
-Reason: implement TODO item for quick overview. 
+2025-09-13: Added mlcls-summary CLI for dataset stats (rows, cols, balance).
+Reason: implement TODO item for quick overview.
 Decisions: compute stats on cleaned data.
+
+2025-09-14: gh-pages workflow now uses GH_PAGES_TOKEN personal token and
+job gated on repository name. AGENTS updated documenting secret.

--- a/TODO.md
+++ b/TODO.md
@@ -244,6 +244,8 @@ scaling.
 
 - [x] document storing GIT_TOKEN as secret for pre-commit in CI
 
+- [ ] configure `GH_PAGES_TOKEN` secret with `contents:write` for docs deployment
+
 ## 23. Release notes
 
 - [x] update CHANGELOG.md with release notes on each version bump
@@ -257,7 +259,6 @@ scaling.
 
 - [x] centralise DATA_PATH via CSV_PATH constant in model modules
 
-
 ## 26. Support vector machine model
 
 - [x] add SVM pipeline, CLI option and tests
@@ -265,4 +266,3 @@ scaling.
 ## 27. Dataset summary CLI
 
 - [x] expose mlcls-summary command printing dataset rows, columns and class balance
-


### PR DESCRIPTION
## Summary
- deploy docs using a personal token
- gate docs job on upstream repository
- document new `GH_PAGES_TOKEN` secret
- log workflow change and track token setup in TODO

## Testing
- `pre-commit` *(failed: authentication for GitHub hooks)*
- `npx markdownlint-cli '**/*.md' --ignore node_modules`

------
https://chatgpt.com/codex/tasks/task_e_684ffbef84d88325867ec881abfca896