### PR TITLE
Update GH Pages token note

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,7 +189,9 @@ ML_classification/
   `gh-pages` branch using `peaceiris/actions-gh-pages@v3`.
   Pushing to this branch requires a token with `contents:write`
   (the default `GITHUB_TOKEN` on forks lacks this permission).
-- Store this token in the `GH_PAGES_TOKEN` secret for the docs job.
+- Store this token in the `GH_PAGES_TOKEN` secret for the docs job. Missing
+  this secret makes `peaceiris/actions-gh-pages` fail with "not found deploy key
+  or tokens".
   Links are checked using:
 
 ```bash

--- a/NOTES.md
+++ b/NOTES.md
@@ -475,4 +475,7 @@ Reason: docs deployment uses this token.
 
 2025-09-14: gh-pages workflow now uses GH_PAGES_TOKEN secret and checks the
 repository name. ci.yml passes GIT_TOKEN to pre-commit so hooks clone
-without prompts. AGENTS updated.
+ without prompts. AGENTS updated.
+2025-09-17: Documented in AGENTS that missing GH_PAGES_TOKEN triggers
+  "not found deploy key or tokens" error from peaceiris/actions-gh-pages.
+  Reason: clarify docs job secret requirement.


### PR DESCRIPTION
## Summary
- document failure message if `GH_PAGES_TOKEN` is missing
- record the docs update in NOTES

## Testing
- `npx markdownlint-cli '**/*.md' --ignore node_modules`
- `find . -name '*.md' -not -path '*node_modules*' -print0 | xargs -0 -n1 npx markdown-link-check -q -c .markdown-link-check.json`

------
https://chatgpt.com/codex/tasks/task_e_68500711ed4c832592ba8552d611157d