### PR TITLE
Fix docs deploy check

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Build docs
         run: sphinx-build -b html docs docs/_build
       - name: Deploy to gh-pages
-        if: secrets.GH_PAGES_TOKEN != ''
+        if: ${{ secrets.GH_PAGES_TOKEN != '' }}
         uses: peaceiris/actions-gh-pages@v3
         with:
           personal_token: ${{ secrets.GH_PAGES_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,6 +192,7 @@ ML_classification/
 - Store this token in the `GH_PAGES_TOKEN` secret for the docs job.
 - The deploy step runs only when `GH_PAGES_TOKEN` is set to avoid failing on
   forks.
+- Wrap any `if` referencing secrets in `${{ }}` to avoid parser errors.
 
 Links are checked using:
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -480,5 +480,8 @@ without prompts. AGENTS updated.
 2025-09-17: gh-pages workflow only deploys when GH_PAGES_TOKEN is set.
 Reason: avoid failing docs job on forks lacking the secret.
 
+2025-09-18: gh-pages workflow wraps GH_PAGES_TOKEN check in ${{ }} and AGENTS
+now warns to do this for all secrets. Reason: avoid YAML parser errors.
+
 2025-06-16: Noted GH_PAGES_TOKEN requirement in README under docs section.
 Reason: clarify needed token to deploy pages.

--- a/TODO.md
+++ b/TODO.md
@@ -276,3 +276,8 @@ scaling.
 ## 29. Docs job token check
 
 - [x] only run Deploy to gh-pages step when GH_PAGES_TOKEN is set (2025-09-17)
+
+## 30. Secret condition syntax
+
+- [x] wrap GH_PAGES_TOKEN check in ${{ }} and mention rule in AGENTS
+  (2025-09-18)


### PR DESCRIPTION
## Summary
- only run gh-pages deploy step when `GH_PAGES_TOKEN` is set using an expression
- document secret-check syntax in `AGENTS.md`
- log the change in `NOTES.md`
- track the task in `TODO.md`

## Testing
- `pre-commit run --files .github/workflows/gh-pages.yml AGENTS.md NOTES.md TODO.md` *(fails: Authentication failed for 'https://github.com/pre-commit/mirrors-markdownlint-cli/')*
- `pytest -k test_smoke.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6850102ca15883259f27494b8585389d