### PR TITLE
Fix GH Pages deployment check

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Build docs
         run: sphinx-build -b html docs docs/_build
       - name: Deploy to gh-pages
-        if: ${{ secrets.GH_PAGES_TOKEN != '' }}
+        if: "${{ secrets.GH_PAGES_TOKEN != '' }}"
         uses: peaceiris/actions-gh-pages@v3
         with:
           personal_token: ${{ secrets.GH_PAGES_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,7 +192,8 @@ ML_classification/
 - Store this token in the `GH_PAGES_TOKEN` secret for the docs job.
 - The deploy step runs only when `GH_PAGES_TOKEN` is set to avoid failing on
   forks.
-- Wrap any `if` referencing secrets in `${{ }}` to avoid parser errors.
+- Wrap any `if` referencing secrets in `${{ }}` and quote the expression
+  (e.g. `if: "${{ secrets.MY_TOKEN != '' }}"`) to avoid YAML parser errors.
 
 Links are checked using:
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -485,3 +485,7 @@ now warns to do this for all secrets. Reason: avoid YAML parser errors.
 
 2025-06-16: Noted GH_PAGES_TOKEN requirement in README under docs section.
 Reason: clarify needed token to deploy pages.
+
+2025-06-16: Quoted GH_PAGES_TOKEN condition in gh-pages workflow and updated AGENTS on quoting secrets. Reason: prevent YAML parse errors.
+
+2025-06-16: Removed trailing blank line in tests/test_cli_manifest.py to fix flake8.

--- a/tests/test_cli_manifest.py
+++ b/tests/test_cli_manifest.py
@@ -37,4 +37,3 @@ def test_cli_manifest(tmp_path) -> None:
     text = out.read_text()
     assert str(f1) in text
     assert "python" in text
-


### PR DESCRIPTION
## Summary
- quote GH_PAGES_TOKEN condition in `gh-pages.yml`
- clarify quoting rule for secrets in AGENTS
- log the change in NOTES
- tidy test file trailing blank line

## Testing
- `black --check .`
- `flake8`
- `make test` *(fails: TypeError in diagnostics_stats)*
- `python - <<'PY'` YAML load check

------
https://chatgpt.com/codex/tasks/task_e_685013e21af48325b112b9c9a2621918