### PR TITLE
docs: record ci quoting fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       - id: files
         uses: tj-actions/changed-files@v41
       - name: Run pre-commit on changed files
-        if: ${{ secrets.GIT_TOKEN != '' }}
+        if: "${{ secrets.GIT_TOKEN != '' }}"
         env:
           GIT_TOKEN: ${{ secrets.GIT_TOKEN }}
         run: pre-commit run --files ${{ steps.files.outputs.all_changed_files }}

--- a/NOTES.md
+++ b/NOTES.md
@@ -488,3 +488,6 @@ Reason: clarify needed token to deploy pages.
 
 2025-09-19: pre-commit step now checks GIT_TOKEN exists in ci.yml.
 Maintainers must define the secret for full checks. Updated AGENTS.
+
+2025-09-20: pre-commit token check in ci.yml is quoted to avoid YAML
+parser errors. Reason: ensures expression parsing works on all runners.

--- a/TODO.md
+++ b/TODO.md
@@ -285,3 +285,8 @@ scaling.
 ## 31. Pre-commit secret check
 
 - [x] run pre-commit only when GIT_TOKEN secret is set (2025-09-19)
+
+## 32. actionlint
+
+- [ ] add actionlint as a pre-commit hook or run manually to catch
+  workflow mistakes


### PR DESCRIPTION
## Summary
- quote the GIT_TOKEN check in the CI workflow
- document the quoting change in NOTES
- suggest actionlint in TODO

## Testing
- `npx -y markdownlint-cli '**/*.md' --ignore node_modules`
- `pytest -q` *(fails: ValueError: pos_label=0 is not a valid label)*
- `pre-commit run --files .github/workflows/ci.yml NOTES.md TODO.md` *(fails: could not read Username)*

------
https://chatgpt.com/codex/tasks/task_e_68501a73129c832585796cf6fa18e107