### PR TITLE
Verify GH_PAGES_TOKEN check

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -489,16 +489,15 @@ Reason: clarify needed token to deploy pages.
 2025-09-19: pre-commit step now checks GIT_TOKEN exists in ci.yml.
 Maintainers must define the secret for full checks. Updated AGENTS.
 
-<<<<<<< codex/fix-ci.yml-secrets-check-syntax
 2025-09-20: Quote GIT_TOKEN condition in ci.yml to avoid YAML errors.
 Reason: follow AGENTS rule on secrets in workflow.
-=======
-<<<<<<< codex/update-agents.md-with-actionlint-instructions
+
 2025-09-20: Added rule to run actionlint on workflow edits.
 Secret conditions must be quoted in AGENTS.
 Reason: keep workflows linted and avoid YAML issues.
-=======
-2025-09-20: pre-commit token check in ci.yml is quoted to avoid YAML
-parser errors. Reason: ensures expression parsing works on all runners.
->>>>>>> main
->>>>>>> main
+
+2025-09-20: pre-commit token check in ci.yml is quoted to avoid YAML parser
+errors. Reason: ensures expression parsing works on all runners.
+
+2025-09-21: Verified gh-pages workflow uses quoted GH_PAGES_TOKEN check and ran
+actionlint.

--- a/TODO.md
+++ b/TODO.md
@@ -286,7 +286,6 @@ scaling.
 
 - [x] run pre-commit only when GIT_TOKEN secret is set (2025-09-19)
 
-
 ## 32. CI quoting fix
 
 - [x] wrap GIT_TOKEN check in ci.yml with quotes to avoid YAML parser errors (2025-09-20)
@@ -300,4 +299,3 @@ scaling.
 
 - [ ] add actionlint as a pre-commit hook or run manually to catch
   workflow mistakes
-


### PR DESCRIPTION
## Summary
- note that GH Pages workflow already checks `GH_PAGES_TOKEN`
- add entry in NOTES about verifying the secret check
- tidy TODO markdown style

## Testing
- `npx markdownlint-cli '**/*.md' --ignore node_modules`
- `pytest -k smoke -q`
- `/root/go/bin/actionlint .github/workflows/gh-pages.yml`

------
https://chatgpt.com/codex/tasks/task_e_685020bd93508325b92303dcbe847fc2