### PR TITLE
docs: clarify actionlint workflow rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,6 +198,9 @@ ML_classification/
   (e.g. `if: "${{ secrets.MY_TOKEN != '' }}"`) to avoid YAML parser errors.
 - Run `actionlint` whenever you change workflow files and verify secret
   conditions are quoted as above.
+- Run `actionlint` after editing workflows and ensure secret checks use
+  exactly `if: "${{ secrets.NAME != '' }}"`. Wrong quoting causes
+  'Unrecognized named-value: 'secrets'' errors in GitHub Actions.
 - The pre-commit config includes an `actionlint` hook so CI lints workflow
   files automatically.
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -509,3 +509,5 @@ errors. Reason: ensures expression parsing works on all runners.
 
 2025-09-21: Verified gh-pages workflow uses quoted GH_PAGES_TOKEN check and ran
 actionlint.
+2025-09-22: Documented actionlint reminder and exact secret check syntax in
+AGENTS to prevent "Unrecognized named-value: 'secrets'" errors.


### PR DESCRIPTION
## Summary
- document actionlint workflow check and exact secret condition quoting
- record the guideline update in NOTES

## Testing
- `npx -y markdownlint-cli '**/*.md' --ignore node_modules`
- `find . -name '*.md' -not -path '*node_modules*' -print0 | xargs -0 -n1 npx -y markdown-link-check -q`

------
https://chatgpt.com/codex/tasks/task_e_6851327774048325bcd195d5943a48e9