### PR TITLE
Update quoting checklist item

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,13 +194,10 @@ ML_classification/
 - Store this token in the `GH_PAGES_TOKEN` secret for the docs job.
 - The deploy step runs only when `GH_PAGES_TOKEN` is set to avoid failing on
   forks.
-- Wrap any `if` referencing secrets in `${{ }}` and quote the expression
-  (e.g. `if: "${{ secrets.MY_TOKEN != '' }}"`) to avoid YAML parser errors.
-- Run `actionlint` whenever you change workflow files and verify secret
-  conditions are quoted as above.
-- Run `actionlint` after editing workflows and ensure secret checks use
-  exactly `if: "${{ secrets.NAME != '' }}"`. Wrong quoting causes
-  'Unrecognized named-value: 'secrets'' errors in GitHub Actions.
+- Detect secret presence in a setup step and store a boolean output.
+  Reference that output in later `if:` conditions instead of checking
+  secrets directly.
+- Run `actionlint` whenever you change workflow files to verify syntax.
 - The pre-commit config includes an `actionlint` hook so CI lints workflow
   files automatically.
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -514,3 +514,5 @@ actionlint.
 
 2025-09-22: Documented actionlint reminder and exact secret check syntax in
 AGENTS to prevent "Unrecognized named-value: 'secrets'" errors.
+
+2025-09-23: Marked obsolete quoting task and added helper-step detection TODO.

--- a/TODO.md
+++ b/TODO.md
@@ -287,7 +287,8 @@ scaling.
 
 ## 32. CI quoting fix
 
-- [x] wrap GIT_TOKEN check in ci.yml with quotes to avoid YAML parser errors (2025-09-20)
+- [x] wrap GIT_TOKEN check in ci.yml with quotes to avoid YAML parser errors
+  (2025-09-20) (obsolete; replaced by helper-step detection)
 
 ## 33. Workflow lint
 
@@ -297,3 +298,8 @@ scaling.
 
 - [x] add actionlint as a pre-commit hook or run manually to catch
   workflow mistakes (2025-09-20)
+
+## 35. Helper-step detection
+
+- [ ] remove secret checks from `if:` conditions and detect token presence
+  via a helper step


### PR DESCRIPTION
## Summary
- mark quoting fix bullet obsolete in TODO and add helper-step detection task
- instruct using helper-step detection instead of secret checks in AGENTS
- log this decision in NOTES

## Testing
- `npx markdownlint-cli '**/*.md' --ignore node_modules`
- `pre-commit run --files AGENTS.md NOTES.md TODO.md` *(fails: could not read Username)*

------
https://chatgpt.com/codex/tasks/task_e_68514b8576048325b7502c29a72075cd