### PR TITLE
Fix markdownlint spacing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,9 @@ ML_classification/
 - After editing docs, run `npx markdownlint-cli` locally before committing.
 - Run `npx markdownlint-cli '**/*.md' --ignore node_modules` to mirror the CI
   job.
+- All Markdown files must be free of trailing spaces. Running
+  `npx markdownlint-cli '**/*.md' --ignore node_modules` (or pre-commit) will
+  catch these issues.
 - `make lint-docs` runs this command automatically.
 - End each Markdown file with exactly one newline to satisfy MD047.
 
@@ -210,7 +213,6 @@ ML_classification/
     secrets directly.
 
   - Run `actionlint` whenever you change workflow files to verify syntax.
-
 
 Links are checked using:
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -464,7 +464,7 @@ Decisions: compute stats on cleaned data.
   `args: ['--profile', 'black']` as required by isort 6.
   Attempted to run `pre-commit` but cloning hook repos failed due to
   missing GitHub token.
-  
+
 2025-09-15: Documented troubleshooting tip for pre-commit failing with
   'could not read Username' in AGENTS.
   Reason: help diagnose GIT_TOKEN errors. Decision: advise checking
@@ -524,14 +524,16 @@ use a helper step to check secrets.
 
 2025-09-23: Marked obsolete quoting task and added helper-step detection TODO.
 
-2025-09-24: Clarified secret checks in AGENTS. 
-Removed outdated quoting guidance and kept 
-helper-step approach as the only method. 
+2025-09-24: Clarified secret checks in AGENTS.
+Removed outdated quoting guidance and kept
+helper-step approach as the only method.
 Updated TODO accordingly.
 
-2025-09-24: Previous notes about quoting secrets are obsolete. 
+2025-09-24: Previous notes about quoting secrets are obsolete.
 All workflows now use a helper step to detect secrets.
 
 2025-09-23: Ticked TODO items for secret helper-step pattern. Completed tasks
 for checking secrets via helper steps and removing secret checks from `if:`
 conditions to avoid YAML errors.
+2025-09-25: Cleaned trailing spaces in NOTES and updated AGENTS.
+Added rule about removing them.

--- a/TODO.md
+++ b/TODO.md
@@ -313,3 +313,8 @@ scaling.
 
 - [x] remove secret checks from `if:` conditions and detect token presence
   via a helper step (2025-09-24)
+
+## 36. Trailing spaces rule
+
+- [x] document in AGENTS that all Markdown files must be free of trailing
+  spaces and enforce with markdownlint (2025-09-25)


### PR DESCRIPTION
## Summary
- fix extra blank line in AGENTS.md
- remove trailing spaces in NOTES.md
- document trailing space rule in AGENTS
- record the rule in TODO
- log the cleanup in NOTES

## Testing
- `yes | npx markdownlint-cli '**/*.md' --ignore node_modules`

------
https://chatgpt.com/codex/tasks/task_e_685157d8ee408325932768512855390c