### PR TITLE
Fix README duplication

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -537,3 +537,6 @@ for checking secrets via helper steps and removing secret checks from `if:`
 conditions to avoid YAML errors.
 2025-09-25: Cleaned trailing spaces in NOTES and updated AGENTS.
 Added rule about removing them.
+
+2025-09-26: Removed duplicate mlcls-eval line from README. Kept single
+example under Command-line usage with mlcls-summary.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ python scripts/download_data.py
 # Train, evaluate and store artefacts in artefacts/
 make train            # run both models
 make eval             # evaluate trained models and check fairness
-mlcls-eval --threshold 0.6  # set fairness metric cutoff
 # or individually
 make train-logreg
 make train-cart
@@ -125,8 +124,7 @@ Use `plot_shap_summary` to turn those values into a PNG stored in
 `artefacts/`.
 
 `make eval` runs `python -m src.evaluate` to compute test metrics and the worst
-mlcls-eval --threshold 0.6  # set fairness metric cutoff
-four-fifths ratio across protected groups (pass `--group-col` to override the
+ four-fifths ratio across protected groups (pass `--group-col` to override the
 default). Metrics are stored in `artefacts/summary_metrics.csv` and printed to
 stdout. A ratio below **0.8** warns of possible bias.
 You can replicate the notebook's exhaustive cross-validation using the training

--- a/TODO.md
+++ b/TODO.md
@@ -318,3 +318,8 @@ scaling.
 
 - [x] document in AGENTS that all Markdown files must be free of trailing
   spaces and enforce with markdownlint (2025-09-25)
+
+## 37. README cleanup
+
+- [x] remove duplicate mlcls-eval command leaving a single example
+  (2025-09-26)


### PR DESCRIPTION
## Summary
- remove duplicate `mlcls-eval` command from workflow instructions
- keep single CLI example with custom threshold and `mlcls-summary`
- document cleanup in NOTES and TODO

## Testing
- `npx markdownlint-cli '**/*.md' --ignore node_modules`

------
https://chatgpt.com/codex/tasks/task_e_68517c4215908325a7c7d513c01a3198