### PR TITLE
Add patch pin note for actionlint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,6 +207,8 @@ ML_classification/
     "Unrecognized named-value: 'secrets'".
   - The pre-commit config includes an `actionlint` hook so CI lints workflow
     files automatically.
+  - Pin `rhysd/actionlint` to the latest patch tag (e.g. `v1.7.7`) because no
+    `v1` alias exists.
 
   - Detect secret presence in a setup step and store a boolean output.
     Reference that output in later `if:` conditions instead of checking

--- a/NOTES.md
+++ b/NOTES.md
@@ -544,3 +544,6 @@ release with helper-step guidance.
 
 2025-09-26: Removed duplicate mlcls-eval line from README. Kept single
 example under Command-line usage with mlcls-summary.
+
+2025-09-27: Documented pinning rhysd/actionlint to a patch tag in AGENTS to
+avoid breakage.

--- a/TODO.md
+++ b/TODO.md
@@ -328,3 +328,8 @@ scaling.
 
 - [x] remove duplicate mlcls-eval command leaving a single example
   (2025-09-26)
+
+## 39. actionlint tag
+
+- [x] pin rhysd/actionlint to patch tag like v1.7.7; no v1 alias
+  (2025-09-27)


### PR DESCRIPTION
## Summary
- note to pin rhysd/actionlint to a specific tag because no `v1` alias exists
- record this note in project history and TODO list

## Testing
- `npx -y markdownlint-cli '**/*.md' --ignore node_modules`

------
https://chatgpt.com/codex/tasks/task_e_685180e5a8c883259b6722ce6a75d7e6