### PR TITLE
docs cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,7 @@ ML_classification/
 - After editing docs, run `npx markdownlint-cli` locally before committing.
 - Run `npx markdownlint-cli '**/*.md' --ignore node_modules` to mirror the CI
   job.
+- After resolving merge conflicts, run `markdownlint` to catch stray markers.
 - All Markdown files must be free of trailing spaces. Running
   `npx markdownlint-cli '**/*.md' --ignore node_modules` (or pre-commit) will
   catch these issues.

--- a/NOTES.md
+++ b/NOTES.md
@@ -550,10 +550,13 @@ Reason: avoid unexpected lint changes from newer versions.
 
 2025-09-27: Documented pinning rhysd/actionlint to a patch tag in AGENTS to
 avoid breakage.
-<<<<<<< codex/update-agents.md-and-notes.md-with-git_token-info
+
 2025-09-28: Documented how missing GIT_TOKEN or blocked network can cause
 pre-commit 'failed to authenticate to GitHub' errors. Check
 ~/.cache/pre-commit/pre-commit.log for details.
-=======
-2025-06-17: evaluate_models cleans data with dataprep.clean at function start. Test updated to work with numeric labels. Reason: normalise Loan_Status early.
->>>>>>> main
+
+2025-06-17: evaluate_models cleans data with dataprep.clean at function start.
+Test updated to work with numeric labels. Reason: normalise Loan_Status early.
+
+2025-09-29: Removed conflict markers from NOTES and TODO. Added cleanup item in
+TODO.md.

--- a/TODO.md
+++ b/TODO.md
@@ -344,4 +344,9 @@ scaling.
   checking ~/.cache/pre-commit/pre-commit.log (2025-09-28)
 
 ## 41. Clean Loan_Status before evaluation
+
 - [x] call dataprep.clean(df) at start of evaluate_models and adjust tests (2025-06-17)
+
+## 42. Resolve merge leftovers
+
+- [x] remove conflict markers from NOTES and TODO (2025-09-29)


### PR DESCRIPTION
## Summary
- clean up conflict markers in NOTES
- clarify lint advice in AGENTS
- add TODO section for resolving merge leftovers

## Testing
- `npx -y markdownlint-cli '**/*.md' --ignore node_modules`

------
https://chatgpt.com/codex/tasks/task_e_68518fa1d38c8325a5d8a6dfbee216cf