### PR TITLE
Update flake8 indent config

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 exclude = .git,__pycache__,.tox,*.egg-info,build,dist,ai_arisha.py
-indent-size = 2
+indent-size = 4
 max-line-length = 88

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,7 @@ ML_classification/
 - Favour composition over inheritance and keep variables scoped tightly.
 - Validate inputs early and throw on bad data.
 - Use 4‑space indentation, single quotes and end files with a newline.
+  `.flake8` enforces this with `indent-size = 4`.
 - Run `isort` automatically via pre-commit to keep imports ordered.
 - Document each public API/function with a doc comment.
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -560,3 +560,5 @@ Test updated to work with numeric labels. Reason: normalise Loan_Status early.
 
 2025-09-29: Removed conflict markers from NOTES and TODO. Added cleanup item in
 TODO.md.
+2025-09-30: flake8 uses indent-size 4. Updated AGENTS.
+Reason: enforce 4-space indentation.

--- a/TODO.md
+++ b/TODO.md
@@ -350,3 +350,7 @@ scaling.
 ## 42. Resolve merge leftovers
 
 - [x] remove conflict markers from NOTES and TODO (2025-09-29)
+
+## 43. Flake8 indentation
+
+- [x] set `indent-size = 4` in .flake8 and document in AGENTS (2025-09-30)


### PR DESCRIPTION
## Summary
- use 4-space indentation in `.flake8`
- note the enforced indent size in AGENTS
- record lint change in NOTES
- add TODO reminder about indent rule

## Testing
- `npx -y markdownlint-cli '**/*.md' --ignore node_modules`
- `find . -name '*.md' -not -path '*node_modules*' -print0 | xargs -0 -n1 npx -y markdown-link-check -c .markdown-link-check.json -q`
- `pytest tests/test_smoke.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685252840a748325b4e1aa435396bf84