### PR TITLE
docs: fix NOTES formatting for markdownlint

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -558,12 +558,13 @@ pre-commit 'failed to authenticate to GitHub' errors. Check
 2025-06-17: evaluate_models cleans data with dataprep.clean at function start.
 Test updated to work with numeric labels. Reason: normalise Loan_Status early.
 
-2025-09-29: Removed conflict markers from NOTES and TODO. Added cleanup item in
-TODO.md.
+2025-09-29: Removed conflict markers from NOTES and TODO. Added cleanup item in TODO.md.
 
 2025-09-30: flake8 uses indent-size 4. Updated AGENTS.
 Reason: enforce 4-space indentation.
 
-2025-09-30: dataset_summary import exposed in src package __init__ so
+2025-09-30: `dataset_summary` import exposed in src package `__init__` so
 `from src import dataset_summary` works. Added unit test verifying the
 function is callable. Reason: align public API with docs.
+2025-06-18: Fixed NOTES formatting for markdownlint. Merged conflict marker.
+Wrapped `dataset_summary` and `__init__`.

--- a/TODO.md
+++ b/TODO.md
@@ -358,3 +358,7 @@ scaling.
 ## 43. Public API update
 
 - [ ] public API now exposes `dataset_summary` via `src` package
+
+## 44. Markdownlint cleanup
+
+- [x] fix NOTES formatting lines 561-569 to satisfy markdownlint (2025-06-18)


### PR DESCRIPTION
## Summary
- fix split line about conflict markers in `NOTES.md`
- wrap code names in backticks
- log the doc tweak in `NOTES.md` and mark as done in `TODO.md`

## Testing
- `npx -y markdownlint-cli '**/*.md' --ignore node_modules`

------
https://chatgpt.com/codex/tasks/task_e_685264b809788325aeeadf57f39931fe