### PR TITLE
docs: tidy TODO headings and tick dataset_summary item

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -564,6 +564,10 @@ TODO.md.
 2025-09-30: flake8 uses indent-size 4. Updated AGENTS.
 Reason: enforce 4-space indentation.
 
-2025-09-30: dataset_summary import exposed in src package __init__ so
+2025-09-30: dataset_summary import exposed in src package `__init__` so
 `from src import dataset_summary` works. Added unit test verifying the
 function is callable. Reason: align public API with docs.
+
+2025-06-18: added blank lines around TODO headings.
+Marked dataset_summary item complete.
+Reason: keep formatting consistent and reflect completion.

--- a/TODO.md
+++ b/TODO.md
@@ -357,4 +357,4 @@ scaling.
 
 ## 43. Public API update
 
-- [ ] public API now exposes `dataset_summary` via `src` package
+- [x] public API now exposes `dataset_summary` via `src` package


### PR DESCRIPTION
## Summary
- tidy headings in TODO
- mark dataset_summary public API task complete
- log the docs cleanup in NOTES

## Testing
- `npx -y markdownlint-cli '**/*.md' --ignore node_modules`

------
https://chatgpt.com/codex/tasks/task_e_685264b9ba3883258aa35306e44d5682