### PR TITLE
docs: note backticks for module names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,7 +147,8 @@ ML_classification/
 
 - Keep lines under 80 characters.
 - Surround lists, headings and fenced code blocks with blank lines.
-- Use backticks around file names containing underscores to avoid MD050.
+- Use backticks around file names containing underscores or module names like
+  `__init__` to avoid MD050.
 - Specify a language for fenced code blocks.
 - NOTES.md and TODO.md entries must keep lines under 80 chars and avoid
   multiple blank lines. Run `npx markdownlint-cli` after updates.

--- a/NOTES.md
+++ b/NOTES.md
@@ -576,3 +576,5 @@ Reason: keep formatting consistent and reflect completion.
 function is callable. Reason: align public API with docs.
 2025-06-18: Fixed NOTES formatting for markdownlint. Merged conflict marker.
 Wrapped `dataset_summary` and `__init__`.
+2025-10-01: AGENTS Markdown bullet now mentions wrapping module names in
+backticks like `__init__`. Reason: avoid MD050.

--- a/TODO.md
+++ b/TODO.md
@@ -362,3 +362,7 @@ scaling.
 ## 44. Markdownlint cleanup
 
 - [x] fix NOTES formatting lines 561-569 to satisfy markdownlint (2025-06-18)
+
+## 45. Markdown style note
+
+- [x] mention wrapping module names like `__init__` in backticks (2025-10-01)


### PR DESCRIPTION
## Summary
- mention wrapping module names like `__init__` in backticks
- log doc update in NOTES
- tick TODO task for style note

## Testing
- `npx --yes markdownlint-cli@0.39.0 AGENTS.md NOTES.md TODO.md`
- `find . -name '*.md' -not -path '*node_modules*' -print0 | xargs -0 -n1 npx --yes markdown-link-check@3 -q -c .markdown-link-check.json`

------
https://chatgpt.com/codex/tasks/task_e_685264bb11e88325bbb7fea1257e463a