### PR TITLE
Version 0.1.3 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,8 @@
 - Added `mlcls-summary` CLI for quick dataset statistics.
 - Replaced secret checks with helper steps to avoid YAML errors.
 - Enforced trailing space rule via markdownlint.
+
+## 0.1.3 - YYYY-MM-DD
+
+- Documented `mlcls-summary` command in README.
+- Public dataset summary CLI available through `mlcls-summary`.

--- a/NOTES.md
+++ b/NOTES.md
@@ -578,3 +578,6 @@ function is callable. Reason: align public API with docs.
 Wrapped `dataset_summary` and `__init__`.
 2025-10-01: AGENTS Markdown bullet now mentions wrapping module names in
 backticks like `__init__`. Reason: avoid MD050.
+
+2025-06-18: Version bumped to 0.1.3 with README example for `mlcls-summary`.
+Reason: document dataset summary CLI before tagging release.

--- a/README.md
+++ b/README.md
@@ -213,6 +213,12 @@ mlcls-manifest      # writes checksums for selected files
 mlcls-summary       # prints dataset statistics
 ```
 
+Example usage:
+
+```bash
+mlcls-summary --data-path data/raw/loan_approval_dataset.csv
+```
+
 These commands require the Kaggle dataset, which is distributed under its
 original licence. See [data/README.md](data/README.md) for details. The dataset
 is small – around 380&nbsp;kB (~1000 rows) – so the default training run

--- a/TODO.md
+++ b/TODO.md
@@ -366,3 +366,7 @@ scaling.
 ## 45. Markdown style note
 
 - [x] mention wrapping module names like `__init__` in backticks (2025-10-01)
+
+## 46. Version 0.1.3 release
+
+- [x] bump version to 0.1.3 and document summary CLI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ml-classification"
-version = "0.1.2"
+version = "0.1.3"
 description = "Loan-approval prediction pipelines"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- bump version to 0.1.3
- document dataset summary CLI in README
- add changelog section for 0.1.3
- log release notes in NOTES and tick TODO

## Testing
- `pytest tests/test_summary.py -q`
- `npx markdownlint-cli '**/*.md' --ignore node_modules` *(failed: asked to install markdownlint-cli)*
- `make test` *(failed: interrupted due to timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68526d847be08325b5bb7d0c578bcfe0