### PR TITLE
Update PAT advice in AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,6 +180,11 @@ ML_classification/
   must define this secret for CI to run the full checks.
 - If pre-commit fails with "could not read Username", verify network access
   and ensure the `GIT_TOKEN` secret is set.
+- A missing or expired personal access token stored in `GIT_TOKEN` will cause
+  `git fetch` errors during pre-commit with the same message. The token must
+  include at least `public_repo` scope (or `repo` for private forks) and should
+  be recreated if the pre-commit log reports authentication errors. Check
+  `~/.cache/pre-commit/pre-commit.log` for details.
 - A missing `GIT_TOKEN` or blocked network may produce "failed to authenticate
   to GitHub" when pre-commit fetches hooks. Check
   `~/.cache/pre-commit/pre-commit.log` for details.

--- a/NOTES.md
+++ b/NOTES.md
@@ -582,7 +582,9 @@ backticks like `__init__`. Reason: avoid MD050.
 2025-06-18: Version bumped to 0.1.3 with README example for `mlcls-summary`.
 Reason: document dataset summary CLI before tagging release.
 
-2025-10-02: Documented mlcls-summary usage in CLI docs 
-and added src.summary to the API reference. 
+2025-10-02: Documented mlcls-summary usage in CLI docs
+and added src.summary to the API reference.
 Reason: user request for dataset summary documentation.
 
+2025-10-03: Documented PAT expiry causing pre-commit `git fetch` failures.
+Reason: clarify CI token issues when "could not read Username" appears.

--- a/TODO.md
+++ b/TODO.md
@@ -374,3 +374,7 @@ scaling.
 ## 46. Dataset summary docs
 
 - [x] document mlcls-summary usage and add src.summary to API reference (2025-10-02)
+
+## 47. Clarify expired PAT
+
+- [x] PAT expiry can break `git fetch`; recreate token if it fails (2025-10-03)


### PR DESCRIPTION
## Summary
- clarify that expired or missing PAT in `GIT_TOKEN` causes `git fetch` failures
- note to recreate token if pre-commit log shows authentication errors
- document update in NOTES and TODO

## Testing
- `npx -y markdownlint-cli '**/*.md' --ignore node_modules`
- `pre-commit run --files AGENTS.md NOTES.md TODO.md` *(fails: could not read Username)*

------
https://chatgpt.com/codex/tasks/task_e_685277fc40a08325921c47e1900dee2b