### PR TITLE
Fix changelog release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - Replaced secret checks with helper steps to avoid YAML errors.
 - Enforced trailing space rule via markdownlint.
 
-## 0.1.3 - YYYY-MM-DD
+## 0.1.3 - 2025-10-02
 
 - Documented `mlcls-summary` command in README.
 - Public dataset summary CLI available through `mlcls-summary`.

--- a/NOTES.md
+++ b/NOTES.md
@@ -586,11 +586,12 @@ Reason: document dataset summary CLI before tagging release.
 and added src.summary to the API reference.
 Reason: user request for dataset summary documentation.
 
-<<<<<<< codex/update-readme-with-ci-git_token-reminder
 2025-10-05: README quick-start clarifies that CI requires the GIT_TOKEN secret.
 It explains how to create a PAT and store it as that secret.
 Reason: user request for clearer setup.
-=======
+
 2025-10-03: Documented PAT expiry causing pre-commit `git fetch` failures.
 Reason: clarify CI token issues when "could not read Username" appears.
->>>>>>> main
+
+2025-10-06: Set 0.1.3 release date in CHANGELOG and removed leftover merge
+markers from NOTES. Reason: keep changelog accurate and pass markdownlint.

--- a/TODO.md
+++ b/TODO.md
@@ -383,3 +383,7 @@ scaling.
 ## 48. Clarify expired PAT
 
 - [x] PAT expiry can break `git fetch`; recreate token if it fails (2025-10-03)
+
+## 49. Update changelog date
+
+- [x] replace placeholder date for version 0.1.3 in CHANGELOG (2025-10-06)


### PR DESCRIPTION
## Summary
- set the release date for version 0.1.3 in `CHANGELOG.md`
- clean merge markers from `NOTES.md` and record the change
- log the update in `TODO.md`

## Testing
- `npx -y markdownlint-cli CHANGELOG.md NOTES.md TODO.md`

------
https://chatgpt.com/codex/tasks/task_e_68529d76c37c8325835955ca0cabc45f