### PR TITLE
docs: clean up NOTES merge markers

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -575,19 +575,16 @@ Reason: document dataset summary CLI before tagging release.
 
 2025-10-02: Documented mlcls-summary usage and its API reference entry.
 Reason: user request for dataset summary documentation.
-<<<<<<< codex/update-release-date-for-version-0.1.3
+
+2025-10-03: Documented PAT expiry causing pre-commit `git fetch` failures.
+Reason: clarify CI token issues when "could not read Username" appears.
 
 2025-10-05: README quick-start clarifies that CI requires the GIT_TOKEN secret.
 It explains how to create a PAT and store it as that secret.
 Reason: user request for clearer setup.
 
-2025-10-03: Documented PAT expiry causing pre-commit `git fetch` failures.
-Reason: clarify CI token issues when "could not read Username" appears.
-
 2025-10-06: Set 0.1.3 release date in CHANGELOG and removed leftover merge
 markers from NOTES. Reason: keep changelog accurate and pass markdownlint.
-=======
-2025-10-03: Documented PAT expiry causing `git fetch` errors and how to fix.
-2025-10-05: README clarifies CI needs a GIT_TOKEN secret and how to create it.
-2025-10-06: Removed leftover merge markers and stray lines. Shortened bullets.
->>>>>>> main
+
+2025-10-07: Removed leftover merge markers from NOTES after merging
+release-date PR. Reason: fix markdownlint errors.

--- a/TODO.md
+++ b/TODO.md
@@ -387,3 +387,7 @@ scaling.
 ## 49. Update changelog date
 
 - [x] replace placeholder date for version 0.1.3 in CHANGELOG (2025-10-06)
+
+## 50. NOTES cleanup after release-date PR
+
+- [x] remove leftover merge markers from NOTES (2025-10-07)


### PR DESCRIPTION
## Summary
- remove conflict markers from NOTES and deduplicate bullets
- note cleanup and changelog date in NOTES
- record cleanup completion in TODO

## Testing
- `npx --yes markdownlint-cli '**/*.md' --ignore node_modules`

------
https://chatgpt.com/codex/tasks/task_e_6852a439aa2c8325a97be76f94e4f443