### PR TITLE
Add model-selection option to evaluation

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -588,3 +588,6 @@ markers from NOTES. Reason: keep changelog accurate and pass markdownlint.
 
 2025-10-07: Removed leftover merge markers from NOTES after merging
 release-date PR. Reason: fix markdownlint errors.
+2025-10-08: evaluate_models now runs random_forest, gboost and svm pipelines and
+supports a --models option to pick which to run. Tests cover the new selection.
+Reason: extend evaluation as requested.

--- a/TODO.md
+++ b/TODO.md
@@ -391,3 +391,8 @@ scaling.
 ## 50. NOTES cleanup after release-date PR
 
 - [x] remove leftover merge markers from NOTES (2025-10-07)
+
+## 51. Extended evaluation models
+
+- [x] evaluate_models supports random_forest, gboost and svm and CLI accepts
+  --models option (2025-10-08)

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -50,6 +50,11 @@ omitted the tool chooses the Youden J statistic::
 
    mlcls-eval --group-col gender --threshold 0.6
 
+Select specific pipelines with ``--models``. Pass multiple names to evaluate
+only those models::
+
+   mlcls-eval --models logreg random_forest svm
+
 The ``advanced_demo.ipynb`` notebook walks through these steps and shows the
 additional plots.
 

--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -1,20 +1,22 @@
 from __future__ import annotations
 
-from pathlib import Path
 import argparse
+from pathlib import Path
+
 import pandas as pd
+from sklearn.ensemble import GradientBoostingClassifier, RandomForestClassifier
 from sklearn.linear_model import LogisticRegression
-from sklearn.tree import DecisionTreeClassifier
 from sklearn.metrics import make_scorer, recall_score
+from sklearn.svm import SVC
+from sklearn.tree import DecisionTreeClassifier
 
-from .cv_utils import nested_cv
 from . import dataprep
-
+from .cv_utils import nested_cv
 from .fairness import (
-    youden_threshold,
-    four_fifths_ratio,
     equal_opportunity_ratio,
     equalized_odds_diff,
+    four_fifths_ratio,
+    youden_threshold,
 )
 
 SPECIFICITY = make_scorer(recall_score, pos_label=0)
@@ -73,37 +75,54 @@ def evaluate_models(
     group_col: str | None = None,
     csv_path: Path = Path("artefacts/summary_metrics.csv"),
     threshold: float | None = None,
+    models: list[str] | None = None,
 ) -> pd.DataFrame:
-    """Return nested-CV metrics for both models and write ``csv_path``.
+    """Return nested-CV metrics and write ``csv_path``.
 
     ``threshold`` sets the probability cutoff used for group metrics. When it
-    is ``None`` the Youden J statistic is used instead.
+    is ``None`` the Youden J statistic is used instead. ``models`` selects which
+    pipelines to run.
     """
     df = dataprep.clean(df)
-    lr_res, X, y = nested_cv(
-        df,
-        target,
-        LogisticRegression(max_iter=1000, solver="liblinear"),
-        {"model__C": [0.3, 1, 3], "model__penalty": ["l1", "l2"]},
-        SCORERS,
-        seed=0,
-        n_splits=3,
-        n_repeats=2,
-        bootstrap_iters=100,
-    )
-    dt_res, _, _ = nested_cv(
-        df,
-        target,
-        DecisionTreeClassifier(random_state=42),
-        {"model__max_depth": [None, 8, 15], "model__min_samples_leaf": [1, 5]},
-        SCORERS,
-        seed=0,
-        n_splits=3,
-        n_repeats=2,
-        bootstrap_iters=100,
-    )
+
+    all_models: dict[str, tuple[object, dict]] = {
+        "logreg": (
+            LogisticRegression(max_iter=1000, solver="liblinear"),
+            {"model__C": [0.3, 1, 3], "model__penalty": ["l1", "l2"]},
+        ),
+        "cart": (
+            DecisionTreeClassifier(random_state=42),
+            {"model__max_depth": [None, 8, 15], "model__min_samples_leaf": [1, 5]},
+        ),
+        "random_forest": (
+            RandomForestClassifier(random_state=42),
+            {"model__n_estimators": [50, 100], "model__max_depth": [None, 10]},
+        ),
+        "gboost": (
+            GradientBoostingClassifier(random_state=42),
+            {"model__n_estimators": [100, 200], "model__learning_rate": [0.05, 0.1]},
+        ),
+        "svm": (
+            SVC(probability=True),
+            {"model__kernel": ["linear", "rbf"], "model__C": [0.1, 1.0]},
+        ),
+    }
+
+    selected = models or list(all_models.keys())
     rows = []
-    for name, res in [("logreg", lr_res), ("cart", dt_res)]:
+    for name in selected:
+        model, grid = all_models[name]
+        res, X, y = nested_cv(
+            df,
+            target,
+            model,
+            grid,
+            SCORERS,
+            seed=0,
+            n_splits=3,
+            n_repeats=2,
+            bootstrap_iters=100,
+        )
         rows.append(
             {
                 "model": name,
@@ -124,6 +143,7 @@ def evaluate_models(
                 ),
             }
         )
+
     out = pd.DataFrame(rows).round(3)
     csv_path.parent.mkdir(parents=True, exist_ok=True)
     out.to_csv(csv_path, index=False)
@@ -144,12 +164,21 @@ def main(args: list[str] | None = None) -> None:
         help="probability cutoff for fairness metrics",
         default=None,
     )
+    parser.add_argument(
+        "--models",
+        nargs="+",
+        choices=["logreg", "cart", "random_forest", "gboost", "svm"],
+        default=None,
+        help="models to evaluate (default: all)",
+    )
     ns = parser.parse_args(args)
 
     from . import dataprep
 
     df = dataprep.clean(dataprep.load_raw())
-    metrics = evaluate_models(df, group_col=ns.group_col, threshold=ns.threshold)
+    metrics = evaluate_models(
+        df, group_col=ns.group_col, threshold=ns.threshold, models=ns.models
+    )
     print(metrics)
 
 

--- a/tests/test_evaluate_extended.py
+++ b/tests/test_evaluate_extended.py
@@ -28,3 +28,9 @@ def test_extended_metrics_and_grid() -> None:
         evaluate.SCORERS,
     )
     assert len(res["estimator"][0].cv_results_["params"]) > 1
+
+
+def test_multiple_models_selection() -> None:
+    df = _df()
+    metrics = evaluate.evaluate_models(df, models=["random_forest", "gboost", "svm"])
+    assert set(metrics["model"]) == {"random_forest", "gboost", "svm"}


### PR DESCRIPTION
## Summary
- support random-forest, gradient-boosting and SVM in `evaluate_models`
- allow choosing models with new `--models` CLI option
- document the option in advanced usage
- test evaluation with selected models
- note the change in NOTES and mark TODO done

## Testing
- `pre-commit run --files NOTES.md TODO.md docs/advanced_usage.rst src/evaluate.py tests/test_evaluate_extended.py`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6852b2f98e7483258929320f464e616b