### PR TITLE
Skip legacy folder from lint hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,17 +4,20 @@ repos:
     hooks:
       - id: isort
         args: ["--profile", "black"]
+        exclude: '^legacy/'
 
   - repo: https://github.com/psf/black
     rev: 23.7.0
     hooks:
       - id: black
         language_version: python3
+        exclude: '^legacy/'
 
   - repo: https://github.com/pycqa/flake8
     rev: 6.1.0
     hooks:
       - id: flake8
+        exclude: '^legacy/'
 
   # ---- markdown-lint (v2, actively maintained) -----------------------------
   - repo: https://github.com/DavidAnson/markdownlint-cli2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,9 @@ github repo in line with README.md to showcase my work. The notebook now lives
 in `legacy/` for reference only.
 
 The style rules apply to new code under `src/` and tests, while
-`legacy/ai_arisha.py` is kept as-is for reference
+`legacy/ai_arisha.py` is kept as-is for reference.
+Pre-commit skips `legacy/ai_arisha.py` and anything under `legacy/` so
+formatters and linters don't touch the old notebook script.
 
 TODO.md, NOTES.md AGENTS.md may be not perfectly aligned with current project
 status. Always recheck in actual code.

--- a/NOTES.md
+++ b/NOTES.md
@@ -595,3 +595,6 @@ Reason: keep repository clean while preserving reference code as per TODO item.
 2025-10-08: evaluate_models now runs random_forest, gboost and svm pipelines and
 supports a --models option to pick which to run. Tests cover the new selection.
 Reason: extend evaluation as requested.
+
+2025-06-18: Pre-commit excludes the legacy folder so isort, black and flake8
+skip ai_arisha.py. Reason: touching that script caused CI failures.

--- a/TODO.md
+++ b/TODO.md
@@ -400,3 +400,7 @@ scaling.
 
 - [x] evaluate_models supports random_forest, gboost and svm and CLI accepts
   --models option (2025-10-08)
+
+## 53. Pre-commit legacy exclusion
+
+- [ ] keep legacy directory excluded from automated linting


### PR DESCRIPTION
## Summary
- skip `legacy/` when running isort, black and flake8
- note the exclusion in AGENTS
- log the change in NOTES
- add a TODO item about keeping lint skips for legacy

## Testing
- `pre-commit run --files .pre-commit-config.yaml AGENTS.md NOTES.md TODO.md`
- `pytest tests/test_smoke.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6852f122268c83258dad4956af24713d