### PR TITLE
Fix docs job dependency in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     outputs:
       docs_only: ${{ steps.docs.outputs.docs_only }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - id: files
@@ -31,9 +31,9 @@ jobs:
     if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Install dependencies
@@ -62,13 +62,13 @@ jobs:
         run: python -m pytest -q
 
   docs:
-    needs: build
+    needs: [build, changes]
     if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Install dependencies
@@ -88,7 +88,7 @@ jobs:
     if: needs.changes.outputs.docs_only == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: '20'

--- a/NOTES.md
+++ b/NOTES.md
@@ -598,3 +598,6 @@ Reason: extend evaluation as requested.
 
 2025-06-18: Pre-commit excludes the legacy folder so isort, black and flake8
 skip ai_arisha.py. Reason: touching that script caused CI failures.
+
+2025-10-09: Docs job now depends on both build and changes jobs. Reason: ensure
+workflow steps run in correct order when docs are built.

--- a/TODO.md
+++ b/TODO.md
@@ -404,3 +404,8 @@ scaling.
 ## 53. Pre-commit legacy exclusion
 
 - [ ] keep legacy directory excluded from automated linting
+
+## 54. CI docs job dependency
+
+- [x] update docs job to depend on both build and changes jobs so the workflow
+  waits for them (2025-10-09)


### PR DESCRIPTION
## Summary
- run docs build after both build and changes jobs
- document the new dependency in NOTES and TODO
- update action versions to satisfy actionlint

## Testing
- `pre-commit run --files .github/workflows/ci.yml NOTES.md TODO.md`
- `make test` *(failed: KeyboardInterrupt after pass)*

------
https://chatgpt.com/codex/tasks/task_e_6855116893f08325a731a7ecfe99d50f