### PR TITLE
Update workflows for Node20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     outputs:
       docs_only: ${{ steps.docs.outputs.docs_only }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - id: files
@@ -31,9 +31,9 @@ jobs:
     if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Install dependencies
@@ -62,13 +62,13 @@ jobs:
         run: python -m pytest -q
 
   docs:
-    needs: build
+    needs: changes
     if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Install dependencies
@@ -88,7 +88,7 @@ jobs:
     if: needs.changes.outputs.docs_only == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: '20'

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -10,8 +10,8 @@ jobs:
     if: github.repository == 'IvanStarostin1984/ML_classification'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Install dependencies
@@ -24,7 +24,7 @@ jobs:
         run: echo "has_token=${{ secrets.GH_PAGES_TOKEN != '' }}" >> "$GITHUB_OUTPUT"
       - name: Deploy to gh-pages
         if: steps.check-token.outputs.has_token == 'true'
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           personal_token: ${{ secrets.GH_PAGES_TOKEN }}
           publish_dir: docs/_build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,11 +9,11 @@ jobs:
   build-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Install build dependencies
@@ -28,7 +28,7 @@ jobs:
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: dist/*.whl
 

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ kaggle.json
 secrets/
 *.key
 *.pem
+
+# Packaging
+requirements.lock
+ml_classification.egg-info/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,6 +204,10 @@ ML_classification/
 - After tests pass, CI builds the Sphinx docs and uploads them using
   `actions/upload-artifact@v4`. Keep the major version current when GitHub
   releases a new one.
+  - Node-based actions are pinned to their Node&nbsp;20 major versions
+    (`actions/checkout@v4`, `actions/setup-python@v5`).
+  - The docs job depends on the `changes` job to check if only Markdown
+    files were modified.
 - The workflow `.github/workflows/gh-pages.yml` deploys these pages to the
   `gh-pages` branch using `peaceiris/actions-gh-pages@v3`.
   Pushing to this branch requires a token with `contents:write`

--- a/NOTES.md
+++ b/NOTES.md
@@ -598,3 +598,6 @@ Reason: extend evaluation as requested.
 
 2025-06-18: Pre-commit excludes the legacy folder so isort, black and flake8
 skip ai_arisha.py. Reason: touching that script caused CI failures.
+
+2025-10-09: Workflows use Node20 actions and docs job depends on changes.
+Reason: actionlint failures from outdated actions and missing dependency.

--- a/TODO.md
+++ b/TODO.md
@@ -403,4 +403,4 @@ scaling.
 
 ## 53. Pre-commit legacy exclusion
 
-- [ ] keep legacy directory excluded from automated linting
+- [x] keep legacy directory excluded from automated linting


### PR DESCRIPTION
## Summary
- use checkout v4 and setup-python v5 in CI, gh-pages, and release flows
- have docs job depend on `changes`
- ignore build artefacts in `.gitignore`
- note Node20 workflows and docs job dependency in AGENTS
- document Node20 update in NOTES and mark legacy exclusion done in TODO

## Testing
- `pre-commit run --files .github/workflows/ci.yml .github/workflows/gh-pages.yml .github/workflows/release.yml .gitignore AGENTS.md NOTES.md TODO.md`
- `pytest -q` *(interrupted after completion)*

------
https://chatgpt.com/codex/tasks/task_e_68551178d6408325ab3d65e100269502