### PR TITLE
Fix indentation in dataprep and tests

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -614,3 +614,4 @@ Reason: remind to run actionlint when workflows change.
 
 2025-10-09: Docs job now depends on both build and changes jobs. Reason: ensure
 workflow steps run in correct order when docs are built.
+2025-10-11: Fixed indentation in dataprep and tests to satisfy flake8 E111.

--- a/TODO.md
+++ b/TODO.md
@@ -415,3 +415,6 @@ scaling.
 
 - [x] update docs job to depend on both build and changes jobs so the workflow
   waits for them (2025-10-09)
+
+## 55. Indentation fixes
+- [x] fix inconsistent indentation causing flake8 E111 (2025-10-11)

--- a/src/dataprep.py
+++ b/src/dataprep.py
@@ -3,14 +3,15 @@
 from __future__ import annotations
 
 from pathlib import Path
+
 import pandas as pd
 
-CSV_PATH = Path('data/raw/loan_approval_dataset.csv')
+CSV_PATH = Path("data/raw/loan_approval_dataset.csv")
 
 
 def load_raw(path: str | Path = CSV_PATH) -> pd.DataFrame:
-  """Return the raw dataset as a ``DataFrame``."""
-  return pd.read_csv(path)
+    """Return the raw dataset as a ``DataFrame``."""
+    return pd.read_csv(path)
 
 
 def clean(df: pd.DataFrame) -> pd.DataFrame:

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import os
-import sys
 import subprocess
+import sys
 from pathlib import Path
 
 import numpy as np
@@ -11,8 +11,8 @@ import pytest
 from sklearn.datasets import make_classification
 from sklearn.linear_model import LogisticRegression
 
-from src.calibration import calibrate_model
 from src import dataprep
+from src.calibration import calibrate_model
 from src.features import FeatureEngineer
 from src.models import logreg
 
@@ -25,17 +25,17 @@ def test_calibrate_model_simple() -> None:
 
 
 def test_calibrate_model_isotonic_fitted() -> None:
-  X, y = make_classification(n_samples=30, n_features=4, random_state=1)
-  model = LogisticRegression().fit(X, y)
-  cal = calibrate_model(model, X, y, method="isotonic")
-  assert hasattr(cal, "calibrated_classifiers_")
+    X, y = make_classification(n_samples=30, n_features=4, random_state=1)
+    model = LogisticRegression().fit(X, y)
+    cal = calibrate_model(model, X, y, method="isotonic")
+    assert hasattr(cal, "calibrated_classifiers_")
 
 
 def test_calibrate_model_invalid_method() -> None:
-  X, y = make_classification(n_samples=20, n_features=4, random_state=2)
-  model = LogisticRegression().fit(X, y)
-  with pytest.raises(ValueError):
-    calibrate_model(model, X, y, method="bad")
+    X, y = make_classification(n_samples=20, n_features=4, random_state=2)
+    model = LogisticRegression().fit(X, y)
+    with pytest.raises(ValueError):
+        calibrate_model(model, X, y, method="bad")
 
 
 def _toy_df(n: int = 40) -> pd.DataFrame:

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,20 +1,25 @@
 import pandas as pd
+
 from src.diagnostics import chi_square_tests, correlation_heatmap
 
 
 def test_chi_square_runs():
-  df = pd.DataFrame({
-    'gender': ['M', 'F', 'M', 'F'],
-    'approved': [1, 0, 1, 0],
-  })
-  res = chi_square_tests(df, 'approved')
-  assert not res.empty
+    df = pd.DataFrame(
+        {
+            "gender": ["M", "F", "M", "F"],
+            "approved": [1, 0, 1, 0],
+        }
+    )
+    res = chi_square_tests(df, "approved")
+    assert not res.empty
 
 
 def test_heatmap_returns_ax():
-  df = pd.DataFrame({
-    'a': [1, 2, 3],
-    'b': [2, 3, 4],
-  })
-  ax = correlation_heatmap(df)
-  assert hasattr(ax, 'figure')
+    df = pd.DataFrame(
+        {
+            "a": [1, 2, 3],
+            "b": [2, 3, 4],
+        }
+    )
+    ax = correlation_heatmap(df)
+    assert hasattr(ax, "figure")


### PR DESCRIPTION
## Summary
- align indentation in `src/dataprep.load_raw` and `clean`
- fix indentation in calibration and diagnostics tests
- document the E111 fix in NOTES and TODO

## Testing
- `pre-commit run --files src/dataprep.py tests/test_calibration.py tests/test_diagnostics.py`
- `flake8`
- `black --check .`
- `pytest -q tests/test_calibration.py tests/test_diagnostics.py` *(partial)*

------
https://chatgpt.com/codex/tasks/task_e_685a502d7d0c832583d989f385b3e2b2