### PR TITLE
docs: clarify markdown blank line rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,8 @@ ML_classification/
 
 - Keep lines under 80 characters.
 - Surround lists, headings and fenced code blocks with blank lines.
+- MD022 (headings) and MD032 (lists) require blank lines before and after.
+  Run `npx markdownlint-cli` or pre-commit before committing.
 - Use backticks around file names containing underscores or module names like
   `__init__` to avoid MD050.
 - Specify a language for fenced code blocks.

--- a/NOTES.md
+++ b/NOTES.md
@@ -615,3 +615,6 @@ Reason: remind to run actionlint when workflows change.
 2025-10-09: Docs job now depends on both build and changes jobs. Reason: ensure
 workflow steps run in correct order when docs are built.
 2025-10-11: Fixed indentation in dataprep and tests to satisfy flake8 E111.
+2025-10-11: Added AGENTS note that MD022 and MD032 require blank lines around
+headings and lists; emphasised running markdownlint or pre-commit. Reason: to
+prevent style violations.

--- a/TODO.md
+++ b/TODO.md
@@ -417,4 +417,10 @@ scaling.
   waits for them (2025-10-09)
 
 ## 55. Indentation fixes
+
 - [x] fix inconsistent indentation causing flake8 E111 (2025-10-11)
+
+## 56. Markdown blank line rule
+
+- [x] note that MD022 and MD032 expect blank lines before and after headings
+  and lists (2025-10-11)


### PR DESCRIPTION
## Summary
- mention MD022 and MD032 blank line rules in AGENTS.md
- log the change in NOTES.md
- track the update in TODO.md

## Testing
- `npx markdownlint-cli '**/*.md' --ignore node_modules`
- `find . -name '*.md' -not -path '*node_modules*' -print0 | xargs -0 -n1 npx markdown-link-check -c .markdown-link-check.json -q`


------
https://chatgpt.com/codex/tasks/task_e_685a5aed069c8325a43ca996acb46278