### PR TITLE
Fix TODO indentation for markdownlint

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -615,3 +615,5 @@ Reason: remind to run actionlint when workflows change.
 2025-10-09: Docs job now depends on both build and changes jobs. Reason: ensure
 workflow steps run in correct order when docs are built.
 2025-10-11: Fixed indentation in dataprep and tests to satisfy flake8 E111.
+2025-06-24: Added blank lines after TODO item 55 heading and list to fix
+markdownlint errors.

--- a/TODO.md
+++ b/TODO.md
@@ -417,4 +417,5 @@ scaling.
   waits for them (2025-10-09)
 
 ## 55. Indentation fixes
+
 - [x] fix inconsistent indentation causing flake8 E111 (2025-10-11)


### PR DESCRIPTION
## Summary
- fix `TODO.md` indentation heading so blank lines are correct
- record the blank-line fix in `NOTES.md`

## Testing
- `pre-commit run --files TODO.md NOTES.md`

------
https://chatgpt.com/codex/tasks/task_e_685a5aebbbf48325b0a92cdbf9e346b2